### PR TITLE
Use a globally accessible WitchBlastGame object

### DIFF
--- a/src/ArtefactDescriptionEntity.cpp
+++ b/src/ArtefactDescriptionEntity.cpp
@@ -5,7 +5,7 @@
 #include "StaticTextEntity.h"
 #include "Items.h"
 
-ArtefactDescriptionEntity::ArtefactDescriptionEntity(enumItemType itemType, WitchBlastGame* parent)
+ArtefactDescriptionEntity::ArtefactDescriptionEntity(enumItemType itemType)
       : SpriteEntity (ImageManager::getImageManager()->getImage(IMAGE_ITEMS_EQUIP), 0, 0, ITEM_WIDTH, ITEM_HEIGHT)
 {
   this->setLifetime(6.0f);
@@ -23,8 +23,6 @@ ArtefactDescriptionEntity::ArtefactDescriptionEntity(enumItemType itemType, Witc
                                       ARTEFACT_RECT_HEIGHT + ARTEFACT_BORDER * 2.0f));
   rectangleBorder.setPosition(sf::Vector2f(x0 - ARTEFACT_BORDER, ARTEFACT_POS_Y - ARTEFACT_BORDER));
   rectangleBorder.setFillColor(sf::Color(255, 255, 255, 180));
-
-  this->parent = parent;
 
   this->x = x0 + 50.0f;
   this->y = 500.0f;

--- a/src/ArtefactDescriptionEntity.h
+++ b/src/ArtefactDescriptionEntity.h
@@ -4,12 +4,10 @@
 #include "sfml_game/SpriteEntity.h"
 #include "ItemEntity.h"
 
-class WitchBlastGame;
-
 class ArtefactDescriptionEntity : public SpriteEntity
 {
   public:
-    ArtefactDescriptionEntity(enumItemType, WitchBlastGame* parent);
+    ArtefactDescriptionEntity(enumItemType);
     ~ArtefactDescriptionEntity();
 
     virtual void animate(float delay);
@@ -17,7 +15,6 @@ class ArtefactDescriptionEntity : public SpriteEntity
   private:
     sf::RectangleShape rectangle;
     sf::RectangleShape rectangleBorder;
-    WitchBlastGame* parent;
 
     std::string artefactName;
     std::string artefactDescription;

--- a/src/BaseCreatureEntity.cpp
+++ b/src/BaseCreatureEntity.cpp
@@ -4,14 +4,13 @@
 
 #include "WitchBlastGame.h"
 
-BaseCreatureEntity::BaseCreatureEntity(sf::Texture* image, WitchBlastGame* parent, float x = 0.0f, float y = 0.0f, int spriteWidth = -1, int spriteHeight = -1)
+BaseCreatureEntity::BaseCreatureEntity(sf::Texture* image, float x = 0.0f, float y = 0.0f, int spriteWidth = -1, int spriteHeight = -1)
   : CollidingSpriteEntity (image, x, y, spriteWidth, spriteHeight )
 {
   hurting = false;
   hurtingType = BoltStandard;
   shadowFrame = -1;
-  parentGame = parent;
-  setMap(parent->getCurrentMap(), TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
+  setMap(game().getCurrentMap(), TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
   hpDisplay = 0;
   for (int i = 0; i < NB_SPECIAL_STATES; i++)
   {

--- a/src/BaseCreatureEntity.h
+++ b/src/BaseCreatureEntity.h
@@ -4,14 +4,12 @@
 #include "sfml_game/CollidingSpriteEntity.h"
 #include "Constants.h"
 
-class WitchBlastGame;
-
 const int NB_SPECIAL_STATES = 1;
 
 class BaseCreatureEntity : public CollidingSpriteEntity
 {
   public:
-    BaseCreatureEntity(sf::Texture* image, WitchBlastGame* parent, float x, float y, int spriteWidth, int spriteHeight);
+    BaseCreatureEntity(sf::Texture* image, float x, float y, int spriteWidth, int spriteHeight);
     int getHp();
     int getHpMax();
     void setHp(int hp);
@@ -47,7 +45,6 @@ class BaseCreatureEntity : public CollidingSpriteEntity
     bool hurting;
     float hurtingDelay;
     enumBoltType hurtingType;
-    WitchBlastGame* parentGame;
     enumBloodColor bloodColor;
   private:
 };

--- a/src/BatEntity.cpp
+++ b/src/BatEntity.cpp
@@ -6,8 +6,8 @@
 #include "Constants.h"
 #include "WitchBlastGame.h"
 
-BatEntity::BatEntity(float x, float y, WitchBlastGame* parent)
-  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_BAT), parent, x, y)
+BatEntity::BatEntity(float x, float y)
+  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_BAT), x, y)
 {
   creatureSpeed = BAT_SPEED;
   velocity = Vector2D(creatureSpeed);
@@ -117,7 +117,7 @@ void BatEntity::dying()
   deadBat->setFrame(FRAME_CORPSE_BAT);
   deadBat->setType(ENTITY_CORPSE);
 
-  for (int i = 0; i < 4; i++) parentGame->generateBlood(x, y, bloodColor);
+  for (int i = 0; i < 4; i++) game().generateBlood(x, y, bloodColor);
 
   drop();
   SoundManager::getSoundManager()->playSound(SOUND_ENNEMY_DYING);

--- a/src/BatEntity.h
+++ b/src/BatEntity.h
@@ -6,7 +6,7 @@
 class BatEntity : public EnnemyEntity
 {
   public:
-    BatEntity(float x, float y, WitchBlastGame* parent);
+    BatEntity(float x, float y);
     virtual void animate(float delay);
     virtual void calculateBB();
   protected:

--- a/src/ChestEntity.cpp
+++ b/src/ChestEntity.cpp
@@ -6,7 +6,7 @@
 #include "sfml_game/SpriteEntity.h"
 #include "Constants.h"
 
-ChestEntity::ChestEntity(float x, float y, int chestType, bool isOpen, WitchBlastGame* parent)
+ChestEntity::ChestEntity(float x, float y, int chestType, bool isOpen)
     : CollidingSpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CHEST), x, y, 48, 48)
 {
   type = ENTITY_CHEST;
@@ -14,8 +14,7 @@ ChestEntity::ChestEntity(float x, float y, int chestType, bool isOpen, WitchBlas
   this->isOpen = isOpen;
   this->chestType = chestType;
   frame = chestType * 2 + (isOpen ? 1 : 0);
-  parentGame = parent;
-  setMap(parent->getCurrentMap(), TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
+  setMap(game().getCurrentMap(), TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
 }
 
 bool ChestEntity::getOpened()
@@ -67,14 +66,14 @@ void ChestEntity::open()
   {
     for (int i = 0; i < 5; i++)
     {
-      ItemEntity* newItem = new ItemEntity(itemCopperCoin, x, y, parentGame);
+      ItemEntity* newItem = new ItemEntity(itemCopperCoin, x, y);
       newItem->setVelocity(Vector2D(50.0f + rand()% 150));
       newItem->setViscosity(0.96f);
     }
   }
   else if (chestType == CHEST_FAIRY)
   {
-    ItemEntity* newItem = new ItemEntity(itemFairy, x, y, parentGame);
+    ItemEntity* newItem = new ItemEntity(itemFairy, x, y);
     newItem->setMap(map, TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
     newItem->setVelocity(Vector2D(50.0f + rand()% 150));
     newItem->setViscosity(0.96f);

--- a/src/ChestEntity.h
+++ b/src/ChestEntity.h
@@ -3,12 +3,10 @@
 
 #include "sfml_game/CollidingSpriteEntity.h"
 
-class WitchBlastGame;
-
 class ChestEntity : public CollidingSpriteEntity
 {
   public:
-    ChestEntity(float x, float y, int chestType, bool isOpen, WitchBlastGame* parent);
+    ChestEntity(float x, float y, int chestType, bool isOpen);
     virtual void animate(float delay);
     virtual void calculateBB();
 
@@ -23,7 +21,6 @@ class ChestEntity : public CollidingSpriteEntity
   private:
     bool isOpen;
     int chestType;
-    WitchBlastGame* parentGame;
 };
 
 #endif // CHESTENTITY_H

--- a/src/DungeonMap.cpp
+++ b/src/DungeonMap.cpp
@@ -403,7 +403,7 @@ void DungeonMap::addChest(int chestType, bool state,  float x, float y)
   chestList.push_back(clm);
 }
 
-void DungeonMap::restoreItems(WitchBlastGame* parent)
+void DungeonMap::restoreItems()
 {
   ItemList::iterator it;
   for (it = itemList.begin (); it != itemList.end ();)
@@ -411,7 +411,7 @@ void DungeonMap::restoreItems(WitchBlastGame* parent)
     itemListElement ilm = *it;
     it++;
 
-    ItemEntity* itemEntity = new ItemEntity((enumItemType)(ilm.type), ilm.x, ilm.y, parent);
+    ItemEntity* itemEntity = new ItemEntity((enumItemType)(ilm.type), ilm.x, ilm.y);
     itemEntity->setMerchandise(ilm.merch);
 	}
 	itemList.clear();
@@ -456,7 +456,7 @@ void DungeonMap::restoreSprites()
 	spriteList.clear();
 }
 
-void DungeonMap::restoreChests(WitchBlastGame* parent)
+void DungeonMap::restoreChests()
 {
   ChestList::iterator it;
 
@@ -465,14 +465,14 @@ void DungeonMap::restoreChests(WitchBlastGame* parent)
     chestListElement clm = *it;
     it++;
 
-    ChestEntity* chestEntity = new ChestEntity(clm.x, clm.y, clm.type, clm.state, parent);
+    ChestEntity* chestEntity = new ChestEntity(clm.x, clm.y, clm.type, clm.state);
 	}
 	chestList.clear();
 }
 
-void DungeonMap::restoreMapObjects(WitchBlastGame* parent)
+void DungeonMap::restoreMapObjects()
 {
-  restoreItems(parent);
+  restoreItems();
   restoreSprites();
-  restoreChests(parent);
+  restoreChests();
 }

--- a/src/DungeonMap.h
+++ b/src/DungeonMap.h
@@ -19,7 +19,6 @@ const int MAP_WALL_3        =   59;
 
 
 class GameFloor;
-class WitchBlastGame;
 
 enum roomTypeEnum
 {
@@ -70,10 +69,10 @@ class DungeonMap : public GameMap
     void addItem(int itemType, float x, float y, bool merch);
     void addSprite(int spriteType, int frame,  float x, float y, float scale);
     void addChest(int chestType, bool state,  float x, float y);
-    void restoreItems(WitchBlastGame* parent);
+    void restoreItems();
     void restoreSprites();
-    void restoreChests(WitchBlastGame* parent);
-    void restoreMapObjects(WitchBlastGame* parent);
+    void restoreChests();
+    void restoreMapObjects();
 
     roomTypeEnum getRoomType();
     void setRoomType(roomTypeEnum roomType);

--- a/src/EnnemyEntity.cpp
+++ b/src/EnnemyEntity.cpp
@@ -8,8 +8,8 @@
 #include <iostream>
 #include "WitchBlastGame.h"
 
-EnnemyEntity::EnnemyEntity(sf::Texture* image, WitchBlastGame* parent, float x, float y)
-    : BaseCreatureEntity (image, parent, x, y, 64, 64)
+EnnemyEntity::EnnemyEntity(sf::Texture* image, float x, float y)
+    : BaseCreatureEntity (image, x, y, 64, 64)
 {
   type = ENTITY_ENNEMY;
   bloodColor = bloodRed;
@@ -82,7 +82,7 @@ void EnnemyEntity::readCollidingEntity(CollidingSpriteEntity* entity)
     {
       boltEntity->collide();
       hurt(boltEntity->getDamages(), boltEntity->getBoltType());
-      parentGame->generateBlood(x, y, bloodColor);
+      game().generateBlood(x, y, bloodColor);
       SoundManager::getSoundManager()->playSound(SOUND_IMPACT);
 
       float xs = (x + boltEntity->getX()) / 2;
@@ -111,7 +111,7 @@ void EnnemyEntity::drop()
 {
   if (rand() % 5 == 0)
   {
-    ItemEntity* newItem = new ItemEntity(itemCopperCoin, x, y, parentGame);
+    ItemEntity* newItem = new ItemEntity(itemCopperCoin, x, y);
     newItem->setMap(map, TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
     newItem->setVelocity(Vector2D(100.0f + rand()% 250));
     newItem->setViscosity(0.96f);

--- a/src/EnnemyEntity.h
+++ b/src/EnnemyEntity.h
@@ -6,7 +6,7 @@
 class EnnemyEntity : public BaseCreatureEntity
 {
   public:
-    EnnemyEntity(sf::Texture* image, WitchBlastGame* parent, float x, float y);
+    EnnemyEntity(sf::Texture* image, float x, float y);
     virtual void animate(float delay);
     virtual void calculateBB();
   protected:

--- a/src/EvilFlowerEntity.cpp
+++ b/src/EvilFlowerEntity.cpp
@@ -9,8 +9,8 @@
 #include "WitchBlastGame.h"
 #include <math.h>
 
-EvilFlowerEntity::EvilFlowerEntity(float x, float y, WitchBlastGame* parent)
-    : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_FLOWER), parent, x, y)
+EvilFlowerEntity::EvilFlowerEntity(float x, float y)
+    : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_FLOWER), x, y)
 {
   hp = EVIL_FLOWER_HP;
   meleeDamages = EVIL_FLOWER_MELEE_DAMAGES;
@@ -65,7 +65,7 @@ void EvilFlowerEntity::dying()
   deadFlower->setFrame(FRAME_CORPSE_FLOWER);
   deadFlower->setType(ENTITY_CORPSE);
 
-  for (int i = 0; i < 4; i++) parentGame->generateBlood(x, y, bloodColor);
+  for (int i = 0; i < 4; i++) game().generateBlood(x, y, bloodColor);
   drop();
   SoundManager::getSoundManager()->playSound(SOUND_ENNEMY_DYING);
 }
@@ -78,13 +78,13 @@ void EvilFlowerEntity::fire()
     bolt->setFrame(1);
     bolt->setMap(map, TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
 
-    float tan = (parentGame->getPlayer()->getX() - x) / (parentGame->getPlayer()->getY() - y);
+    float tan = (game().getPlayer()->getX() - x) / (game().getPlayer()->getY() - y);
     float angle = atan(tan);
 
     float flowerFireVelocity = EVIL_FLOWER_FIRE_VELOCITY;
     if (specialState[SpecialStateIce].active) flowerFireVelocity *= 0.5f;
 
-    if (parentGame->getPlayer()->getY() > y)
+    if (game().getPlayer()->getY() > y)
       bolt->setVelocity(Vector2D(sin(angle) * flowerFireVelocity,
                                  cos(angle) * flowerFireVelocity));
     else

--- a/src/EvilFlowerEntity.h
+++ b/src/EvilFlowerEntity.h
@@ -7,7 +7,7 @@
 class EvilFlowerEntity : public EnnemyEntity
 {
   public:
-    EvilFlowerEntity(float x, float y, WitchBlastGame* parent);
+    EvilFlowerEntity(float x, float y);
     virtual void animate(float delay);
     virtual void calculateBB();
     virtual void render(sf::RenderWindow* app);

--- a/src/GreenRatEntity.cpp
+++ b/src/GreenRatEntity.cpp
@@ -7,8 +7,8 @@
 #include "Constants.h"
 #include "WitchBlastGame.h"
 
-GreenRatEntity::GreenRatEntity(float x, float y, WitchBlastGame* parent)
-  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_RAT), parent, x, y)
+GreenRatEntity::GreenRatEntity(float x, float y)
+  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_RAT), x, y)
 {
   imagesProLine = 4;
   creatureSpeed = GREEN_RAT_SPEED;
@@ -37,10 +37,10 @@ void GreenRatEntity::animate(float delay)
         if (timer <= 0.0f)
         {
           timer = (rand() % 50) / 10.0f;
-          float tan = (parentGame->getPlayer()->getX() - x) / (parentGame->getPlayer()->getY() - y);
+          float tan = (game().getPlayer()->getX() - x) / (game().getPlayer()->getY() - y);
           float angle = atan(tan);
 
-          if (parentGame->getPlayer()->getY() > y)
+          if (game().getPlayer()->getY() > y)
             setVelocity(Vector2D(sin(angle) * RAT_SPEED,
                                        cos(angle) * RAT_SPEED));
           else
@@ -93,7 +93,7 @@ void GreenRatEntity::dying()
   deadRat->setFrame(FRAME_CORPSE_GREEN_RAT);
   deadRat->setType(ENTITY_CORPSE);
 
-  for (int i = 0; i < 4; i++) parentGame->generateBlood(x, y, bloodColor);
+  for (int i = 0; i < 4; i++) game().generateBlood(x, y, bloodColor);
   //drop();
   SoundManager::getSoundManager()->playSound(SOUND_ENNEMY_DYING);
 }

--- a/src/GreenRatEntity.h
+++ b/src/GreenRatEntity.h
@@ -7,7 +7,7 @@
 class GreenRatEntity : public EnnemyEntity
 {
   public:
-    GreenRatEntity(float x, float y, WitchBlastGame* parent);
+    GreenRatEntity(float x, float y);
     virtual void animate(float delay);
     virtual void calculateBB();
   protected:

--- a/src/ItemEntity.cpp
+++ b/src/ItemEntity.cpp
@@ -10,7 +10,7 @@
 
 
 
-ItemEntity::ItemEntity(enumItemType itemType, float x, float y, WitchBlastGame* parent)
+ItemEntity::ItemEntity(enumItemType itemType, float x, float y)
     : CollidingSpriteEntity(ImageManager::getImageManager()->getImage(itemType >= itemMagicianHat ? IMAGE_ITEMS_EQUIP : IMAGE_ITEMS), x, y, ITEM_WIDTH, ITEM_HEIGHT)
 {
   type = ENTITY_ITEM;
@@ -19,8 +19,7 @@ ItemEntity::ItemEntity(enumItemType itemType, float x, float y, WitchBlastGame* 
   if (itemType >= itemMagicianHat) frame = itemType - itemMagicianHat;
   isMerchandise = false;
   imagesProLine = 10;
-  this->parentGame = parent;
-  setMap(parent->getCurrentMap(), TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
+  setMap(game().getCurrentMap(), TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
 }
 
 void ItemEntity::setMerchandise(bool isMerchandise)
@@ -36,12 +35,6 @@ int ItemEntity::getPrice()
 {
   return (items[itemType].price);
 }
-
-void ItemEntity::setParent(WitchBlastGame* parent)
-{
-  parentGame = parent;
-}
-
 
 void ItemEntity::animate(float delay)
 {
@@ -100,7 +93,7 @@ void ItemEntity::readCollidingEntity(CollidingSpriteEntity* entity)
           if (itemType >= itemMagicianHat)
           {
 
-            parentGame->showArtefactDescription(itemType);
+            game().showArtefactDescription(itemType);
             SpriteEntity* spriteItem = new SpriteEntity(
                             image,
                             playerEntity->getX(), playerEntity->getY() - 60.0f, ITEM_WIDTH, ITEM_HEIGHT);

--- a/src/ItemEntity.h
+++ b/src/ItemEntity.h
@@ -4,12 +4,10 @@
 #include "sfml_game/CollidingSpriteEntity.h"
 #include "Items.h"
 
-class WitchBlastGame;
-
 class ItemEntity : public CollidingSpriteEntity
 {
   public:
-    ItemEntity(enumItemType itemType, float x, float y, WitchBlastGame* parent);
+    ItemEntity(enumItemType itemType, float x, float y);
     void setMerchandise(bool isMerchandise);
     bool getMerchandise();
     int getPrice();
@@ -18,11 +16,9 @@ class ItemEntity : public CollidingSpriteEntity
     virtual void render(sf::RenderWindow* app);
     virtual void calculateBB();
     virtual void dying();
-    void setParent(WitchBlastGame* parent);
     enumItemType getItemType() { return itemType; };
 
   protected:
-    WitchBlastGame* parentGame;
     enumItemType itemType;
 
     bool isMerchandise;

--- a/src/KingRatEntity.cpp
+++ b/src/KingRatEntity.cpp
@@ -11,8 +11,8 @@
 
 #include <iostream>
 
-KingRatEntity::KingRatEntity(float x, float y, WitchBlastGame* parent)
-  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_KING_RAT), parent, x, y)
+KingRatEntity::KingRatEntity(float x, float y)
+  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_KING_RAT), x, y)
 {
   width = 128;
   height = 128;
@@ -123,10 +123,10 @@ void KingRatEntity::animate(float delay)
       // rush
       timer = 12.0f;
 
-      float tan = (parentGame->getPlayer()->getX() - x) / (parentGame->getPlayer()->getY() - y);
+      float tan = (game().getPlayer()->getX() - x) / (game().getPlayer()->getY() - y);
       float angle = atan(tan);
 
-      if (parentGame->getPlayer()->getY() > y)
+      if (game().getPlayer()->getY() > y)
         setVelocity(Vector2D(sin(angle) * KING_RAT_RUNNING_SPEED,
                                        cos(angle) * KING_RAT_RUNNING_SPEED));
       else
@@ -169,10 +169,10 @@ void KingRatEntity::animate(float delay)
       berserkDelay = 0.8f + (rand()%10) / 10.0f;
       SoundManager::getSoundManager()->playSound(SOUND_KING_RAT_2);
 
-      float tan = (parentGame->getPlayer()->getX() - x) / (parentGame->getPlayer()->getY() - y);
+      float tan = (game().getPlayer()->getX() - x) / (game().getPlayer()->getY() - y);
       float angle = atan(tan);
 
-      if (parentGame->getPlayer()->getY() > y)
+      if (game().getPlayer()->getY() > y)
         setVelocity(Vector2D(sin(angle) * KING_RAT_BERSERK_SPEED,
                                        cos(angle) * KING_RAT_BERSERK_SPEED));
       else
@@ -290,7 +290,7 @@ void KingRatEntity::dying()
   deadRat->setFrame(FRAME_CORPSE_KING_RAT - FRAME_CORPSE_KING_RAT);
   deadRat->setType(ENTITY_CORPSE);
 
-  for (int i = 0; i < 10; i++) parentGame->generateBlood(x, y, bloodColor);
+  for (int i = 0; i < 10; i++) game().generateBlood(x, y, bloodColor);
 
   SoundManager::getSoundManager()->playSound(SOUND_KING_RAT_DIE);
 }
@@ -305,7 +305,7 @@ void KingRatEntity::generateGreenRats()
     if (xr > OFFSET_X + TILE_WIDTH * 1.5f && xr < OFFSET_X + TILE_WIDTH * (MAP_WIDTH - 2)
         && yr > OFFSET_Y + TILE_HEIGHT * 1.5f && yr < OFFSET_Y + TILE_HEIGHT * (MAP_HEIGHT - 2))
     {
-      new GreenRatEntity(xr, yr, parentGame);
+      new GreenRatEntity(xr, yr);
     }
     else
       i--;

--- a/src/KingRatEntity.h
+++ b/src/KingRatEntity.h
@@ -7,7 +7,7 @@
 class KingRatEntity : public EnnemyEntity
 {
   public:
-    KingRatEntity(float x, float y, WitchBlastGame* parent);
+    KingRatEntity(float x, float y);
     virtual void animate(float delay);
     virtual void render(sf::RenderWindow* app);
     virtual void calculateBB();

--- a/src/PlayerEntity.cpp
+++ b/src/PlayerEntity.cpp
@@ -10,8 +10,8 @@
 
 #include <iostream>
 
-PlayerEntity::PlayerEntity(sf::Texture* image, WitchBlastGame* parent, float x = 0.0f, float y = 0.0f)
-      : BaseCreatureEntity (image, parent, x, y, 64, 96)
+PlayerEntity::PlayerEntity(sf::Texture* image, float x = 0.0f, float y = 0.0f)
+      : BaseCreatureEntity (image, x, y, 64, 96)
 {
   currentFireDelay = -1.0f;
   canFirePlayer = true;
@@ -140,13 +140,13 @@ void PlayerEntity::animate(float delay)
     frame = 0; //1;
 
   if (x < OFFSET_X)
-    parentGame->moveToOtherMap(4);
+    game().moveToOtherMap(4);
   else if (x > OFFSET_X + MAP_WIDTH * TILE_WIDTH)
-    parentGame->moveToOtherMap(6);
+    game().moveToOtherMap(6);
   else if (y < OFFSET_Y)
-    parentGame->moveToOtherMap(8);
+    game().moveToOtherMap(8);
   else if (y > OFFSET_Y + MAP_HEIGHT * TILE_HEIGHT - 5)
-    parentGame->moveToOtherMap(2);
+    game().moveToOtherMap(2);
 
   if (playerStatus == playerStatusEntering)
   {
@@ -156,7 +156,7 @@ void PlayerEntity::animate(float delay)
         && (boundingBox.top + boundingBox.height) < OFFSET_Y + TILE_HEIGHT * (MAP_HEIGHT - 1))
     {
       playerStatus = playerStatusPlaying;
-      parentGame->closeDoors();
+      game().closeDoors();
     }
   }
 
@@ -357,7 +357,7 @@ void PlayerEntity::readCollidingEntity(CollidingSpriteEntity* entity)
       {
         boltEntity->collide();
         hurt(boltEntity->getDamages());
-        parentGame->generateBlood(x, y, bloodColor);
+        game().generateBlood(x, y, bloodColor);
       }
     }
 }
@@ -509,8 +509,8 @@ bool PlayerEntity::hurt(int damages)
   {
     SoundManager::getSoundManager()->playSound(SOUND_PLAYER_HIT);
     BaseCreatureEntity::hurt(damages, BoltStandard);
-    parentGame->generateBlood(x, y, bloodColor);
-    parentGame->generateBlood(x, y, bloodColor);
+    game().generateBlood(x, y, bloodColor);
+    game().generateBlood(x, y, bloodColor);
     return true;
   }
   return false;
@@ -543,7 +543,7 @@ void PlayerEntity::dying()
   for (i = 0; i < NUMBER_EQUIP_ITEMS; i++)
     if (equip[i]) loseItem(enumItemType(i), true);
 
-  for (i = 0; i < 8; i++) parentGame->generateBlood(x, y, bloodColor);
+  for (i = 0; i < 8; i++) game().generateBlood(x, y, bloodColor);
 
   CollidingSpriteEntity* itemSprite
     = new CollidingSpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_PLAYER), x, y, 64, 64);

--- a/src/PlayerEntity.h
+++ b/src/PlayerEntity.h
@@ -10,7 +10,7 @@ class FairyEntity;
 class PlayerEntity : public BaseCreatureEntity
 {
   public:
-    PlayerEntity(sf::Texture* image, WitchBlastGame* parent, float x, float y);
+    PlayerEntity(sf::Texture* image, float x, float y);
     virtual void animate(float delay);
     virtual void render(sf::RenderWindow* app);
 

--- a/src/RatEntity.cpp
+++ b/src/RatEntity.cpp
@@ -7,8 +7,8 @@
 #include "Constants.h"
 #include "WitchBlastGame.h"
 
-RatEntity::RatEntity(float x, float y, WitchBlastGame* parent)
-  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_RAT), parent, x, y)
+RatEntity::RatEntity(float x, float y)
+  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_RAT), x, y)
 {
   creatureSpeed = RAT_SPEED;
   velocity = Vector2D(creatureSpeed);
@@ -65,7 +65,7 @@ void RatEntity::dying()
   deadRat->setFrame(FRAME_CORPSE_RAT);
   deadRat->setType(ENTITY_CORPSE);
 
-  for (int i = 0; i < 4; i++) parentGame->generateBlood(x, y, bloodColor);
+  for (int i = 0; i < 4; i++) game().generateBlood(x, y, bloodColor);
   drop();
   SoundManager::getSoundManager()->playSound(SOUND_ENNEMY_DYING);
 }

--- a/src/RatEntity.h
+++ b/src/RatEntity.h
@@ -6,7 +6,7 @@
 class RatEntity : public EnnemyEntity
 {
   public:
-    RatEntity(float x, float y, WitchBlastGame* parent);
+    RatEntity(float x, float y);
     virtual void animate(float delay);
     virtual void calculateBB();
   protected:

--- a/src/SlimeEntity.cpp
+++ b/src/SlimeEntity.cpp
@@ -6,8 +6,8 @@
 #include "Constants.h"
 #include "WitchBlastGame.h"
 
-SlimeEntity::SlimeEntity(float x, float y, WitchBlastGame* parent)
-  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_SLIME), parent, x, y)
+SlimeEntity::SlimeEntity(float x, float y)
+  : EnnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_SLIME), x, y)
 {
   creatureSpeed = 0.0f;
   velocity = Vector2D(0.0f, 0.0f);
@@ -76,10 +76,10 @@ void SlimeEntity::animate(float delay)
 
       if (rand() % 2 == 0)
       {
-        float tan = (parentGame->getPlayer()->getX() - x) / (parentGame->getPlayer()->getY() - y);
+        float tan = (game().getPlayer()->getX() - x) / (game().getPlayer()->getY() - y);
         float angle = atan(tan);
 
-        if (parentGame->getPlayer()->getY() > y)
+        if (game().getPlayer()->getY() > y)
           setVelocity(Vector2D(sin(angle) * randVel,
                                      cos(angle) * randVel));
         else
@@ -206,7 +206,7 @@ void SlimeEntity::dying()
   deadSlime->setFrame(FRAME_CORPSE_SLIME);
   deadSlime->setType(ENTITY_CORPSE);
 
-  for (int i = 0; i < 4; i++) parentGame->generateBlood(x, y, bloodColor);
+  for (int i = 0; i < 4; i++) game().generateBlood(x, y, bloodColor);
 
   drop();
   SoundManager::getSoundManager()->playSound(SOUND_ENNEMY_DYING);

--- a/src/SlimeEntity.h
+++ b/src/SlimeEntity.h
@@ -7,7 +7,7 @@
 class SlimeEntity : public EnnemyEntity
 {
   public:
-    SlimeEntity(float x, float y, WitchBlastGame* parent);
+    SlimeEntity(float x, float y);
     virtual void animate(float delay);
     virtual void render(sf::RenderWindow* app);
     virtual void calculateBB();

--- a/src/WitchBlastGame.cpp
+++ b/src/WitchBlastGame.cpp
@@ -23,8 +23,13 @@
 #include <sstream>
 #include <fstream>
 
+namespace {
+WitchBlastGame* gameptr;
+}
+
 WitchBlastGame::WitchBlastGame(): Game(SCREEN_WIDTH, SCREEN_HEIGHT)
 {
+  gameptr = this;
   app->setTitle(APP_NAME + " V" + APP_VERSION);
 
   // loading resources
@@ -161,7 +166,6 @@ void WitchBlastGame::startNewGame(bool fromSaveFile)
 
     // the player
     player = new PlayerEntity(ImageManager::getImageManager()->getImage(0),
-                              this,
                               OFFSET_X + (TILE_WIDTH * MAP_WIDTH * 0.5f),
                               OFFSET_Y + (TILE_HEIGHT * MAP_HEIGHT * 0.5f));
 
@@ -205,7 +209,7 @@ void WitchBlastGame::startNewGame(bool fromSaveFile)
   // generate the map
   refreshMap();
   // items from save
-  currentMap->restoreMapObjects(this);
+  currentMap->restoreMapObjects();
 
   // first map is open
   roomClosed = false;
@@ -595,7 +599,7 @@ void WitchBlastGame::moveToOtherMap(int direction)
   }
   refreshMap();
   checkEntering();
-  currentMap->restoreMapObjects(this);
+  currentMap->restoreMapObjects();
 }
 
 void WitchBlastGame::onRender()
@@ -744,7 +748,7 @@ void WitchBlastGame::generateBlood(float x, float y, BaseCreatureEntity::enumBlo
 
 void WitchBlastGame::showArtefactDescription(enumItemType itemType)
 {
-  new ArtefactDescriptionEntity(itemType, this); //, &font);
+  new ArtefactDescriptionEntity(itemType); //, &font);
 }
 
 void WitchBlastGame::generateMap()
@@ -758,17 +762,17 @@ void WitchBlastGame::generateMap()
     int bonusType = getRandomEquipItem(false);
     if (bonusType == EQUIP_FAIRY)
     {
-      new ChestEntity(v.x, v.y, CHEST_FAIRY, false, this);
+      new ChestEntity(v.x, v.y, CHEST_FAIRY, false);
     }
     else
     {
-      new ItemEntity( (enumItemType)(itemMagicianHat + bonusType), v.x ,v.y, this);
+      new ItemEntity( (enumItemType)(itemMagicianHat + bonusType), v.x ,v.y);
     }
   }
   else if (currentMap->getRoomType() == roomTypeKey)
   {
     Vector2D v = currentMap->generateKeyRoom();
-    new ItemEntity( (enumItemType)(itemBossKey), v.x ,v.y, this);
+    new ItemEntity( (enumItemType)(itemBossKey), v.x ,v.y);
     initMonsterArray();
     int x0 = MAP_WIDTH / 2;
     int y0 = MAP_HEIGHT / 2;
@@ -783,16 +787,14 @@ void WitchBlastGame::generateMap()
     ItemEntity* item1 = new ItemEntity(
       itemHealth,
       OFFSET_X + (MAP_WIDTH / 2 - 2) * TILE_WIDTH + TILE_WIDTH / 2,
-      OFFSET_Y + (MAP_HEIGHT / 2) * TILE_HEIGHT,
-      this);
+      OFFSET_Y + (MAP_HEIGHT / 2) * TILE_HEIGHT);
     item1->setMerchandise(true);
 
     int bonusType = getRandomEquipItem(true);
     ItemEntity* item2 = new ItemEntity(
       (enumItemType)(itemMagicianHat + bonusType),
       OFFSET_X + (MAP_WIDTH / 2 + 2) * TILE_WIDTH + TILE_WIDTH / 2,
-      OFFSET_Y + (MAP_HEIGHT / 2) * TILE_HEIGHT,
-      this);
+      OFFSET_Y + (MAP_HEIGHT / 2) * TILE_HEIGHT);
     item2->setMerchandise(true);
 
     new PnjEntity(OFFSET_X + (MAP_WIDTH / 2) * TILE_WIDTH + TILE_WIDTH / 2,
@@ -806,8 +808,7 @@ void WitchBlastGame::generateMap()
     currentMap->generateRoom(0);
 
     boss = new KingRatEntity(OFFSET_X + (MAP_WIDTH / 2 - 2) * TILE_WIDTH + TILE_WIDTH / 2,
-                      OFFSET_Y + (MAP_HEIGHT / 2 - 2) * TILE_HEIGHT + TILE_HEIGHT / 2,
-                      this);
+                      OFFSET_Y + (MAP_HEIGHT / 2 - 2) * TILE_HEIGHT + TILE_HEIGHT / 2);
   }
   else if (currentMap->getRoomType() == roomTypeStarting)
   {
@@ -818,14 +819,13 @@ void WitchBlastGame::generateMap()
     {
       new ChestEntity(OFFSET_X + (TILE_WIDTH * MAP_WIDTH * 0.5f),
                                            OFFSET_Y + 120.0f + (TILE_HEIGHT * MAP_HEIGHT * 0.5f),
-                                           CHEST_FAIRY, false, this);
+                                           CHEST_FAIRY, false);
     }
     else
     {
       new ItemEntity( (enumItemType)(itemMagicianHat + bonusType),
                           OFFSET_X + (TILE_WIDTH * MAP_WIDTH * 0.5f),
-                          OFFSET_Y + 120.0f + (TILE_HEIGHT * MAP_HEIGHT * 0.5f),
-                          this);
+                          OFFSET_Y + 120.0f + (TILE_HEIGHT * MAP_HEIGHT * 0.5f));
     }
   }
   else if (currentMap->getRoomType() == roomTypeExit)
@@ -848,12 +848,12 @@ void WitchBlastGame::addMonster(monster_type_enum monsterType, float xm, float y
 {
   switch (monsterType)
   {
-    case MONSTER_RAT: new RatEntity(xm, ym - 2, this); break;
-    case MONSTER_BAT: new BatEntity(xm, ym, this); break;
-    case MONSTER_EVIL_FLOWER: new EvilFlowerEntity(xm, ym, this); break;
-    case MONSTER_SLIME: new SlimeEntity(xm, ym, this); break;
+    case MONSTER_RAT: new RatEntity(xm, ym - 2); break;
+    case MONSTER_BAT: new BatEntity(xm, ym); break;
+    case MONSTER_EVIL_FLOWER: new EvilFlowerEntity(xm, ym); break;
+    case MONSTER_SLIME: new SlimeEntity(xm, ym); break;
 
-    case MONSTER_KING_RAT: new KingRatEntity(xm, ym, this); break;
+    case MONSTER_KING_RAT: new KingRatEntity(xm, ym); break;
   }
 }
 
@@ -927,7 +927,7 @@ void WitchBlastGame::generateStandardMap()
   else if (random < 64)
   {
     Vector2D v = currentMap->generateBonusRoom();
-    new ChestEntity(v.x, v.y, CHEST_BASIC, false, this);
+    new ChestEntity(v.x, v.y, CHEST_BASIC, false);
     currentMap->setCleared(true);
   }
   else if (random < 80)
@@ -1229,7 +1229,6 @@ bool WitchBlastGame::loadGame()
     int hp, hpMax, gold;
     file >> hp >> hpMax >> gold;
     player = new PlayerEntity(ImageManager::getImageManager()->getImage(0),
-                              this,
                               OFFSET_X + (TILE_WIDTH * MAP_WIDTH * 0.5f),
                               OFFSET_Y + (TILE_HEIGHT * MAP_HEIGHT * 0.5f));
     player->setHp(hp);
@@ -1255,4 +1254,10 @@ bool WitchBlastGame::loadGame()
   }
 
   return true;
+}
+
+
+WitchBlastGame &game()
+{
+    return *gameptr;
 }

--- a/src/WitchBlastGame.h
+++ b/src/WitchBlastGame.h
@@ -95,4 +95,6 @@ class WitchBlastGame : public Game
     bool isPlayerAlive;
 };
 
+WitchBlastGame& game();
+
 #endif // MAGICGAME_H


### PR DESCRIPTION
- Add game() function, which returns the
  single instance of WitchBlastGame.
  
  This way, we can avoid the inconvenience of having to pass
  a WitchBlastGame reference to every object that wants to use it.
- Replace every WitchBlastGame reference with game().
