### PR TITLE
Tell GCC/Clang to build in C++11 mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,19 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Projet name
 project("Witch_Blast")
+
+# Detect compiler
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(USING_GCC TRUE)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(USING_CLANG TRUE)
+endif()
+
+# For GCC and Clang, enable C++11 support and add some other flags
+if(USING_GCC OR USING_CLANG)
+  add_compile_options(-std=c++11 -pedantic -Wall)
+endif()
 
 file(
         GLOB_RECURSE


### PR DESCRIPTION
The [override](http://en.cppreference.com/w/cpp/language/override)
specifier is a C++11 feature.

Some compilers (like GCC and Clang) build in C++03 mode by default, and
you must explicitly tell them to build in C++11 mode.

The easiest way to do this is to use `CMAKE_CXX_COMPILER_ID` for detecting
the compiler, and `add_compile_options` for passing the correct
options to it.

These features require CMake 2.8.12, so we set the minimum required CMake
version to it.
