### PR TITLE
Rename singleton getters to getInstance(), return references

### DIFF
--- a/src/ArtefactDescriptionEntity.cpp
+++ b/src/ArtefactDescriptionEntity.cpp
@@ -6,7 +6,7 @@
 #include "TextMapper.h"
 
 ArtefactDescriptionEntity::ArtefactDescriptionEntity(enumItemType itemType)
-      : SpriteEntity (ImageManager::getImageManager()->getImage(itemType >= FirstEquipItem ? IMAGE_ITEMS_EQUIP : IMAGE_ITEMS ),
+      : SpriteEntity (ImageManager::getInstance().getImage(itemType >= FirstEquipItem ? IMAGE_ITEMS_EQUIP : IMAGE_ITEMS ),
                       0, 0, ITEM_WIDTH, ITEM_HEIGHT)
 {
   this->setLifetime(6.0f);

--- a/src/BaseCreatureEntity.cpp
+++ b/src/BaseCreatureEntity.cpp
@@ -361,7 +361,7 @@ int BaseCreatureEntity::determineDamageBonus(enumStateResistance resistance, int
 
 bool BaseCreatureEntity::textTooClose(TextEntity* textEntity, float xDistMin, float yDistMin)
 {
-  EntityManager::EntityList* entityList =EntityManager::getEntityManager()->getList();
+  EntityManager::EntityList* entityList =EntityManager::getInstance().getList();
   EntityManager::EntityList::iterator it;
 
 	for (it = entityList->begin (); it != entityList->end ();)
@@ -503,7 +503,7 @@ bool BaseCreatureEntity::hurt(int damages, enumShotType hurtingType, int level, 
       textCrit->setType(ENTITY_FLYING_TEXT);
     }
 
-    if (critical) SoundManager::getSoundManager()->playSound(SOUND_CRITICAL);
+    if (critical) SoundManager::getInstance().playSound(SOUND_CRITICAL);
 
     return true;
   }
@@ -573,7 +573,7 @@ bool BaseCreatureEntity::canCollide()
 void BaseCreatureEntity::generateStar(sf::Color starColor)
 {
   SpriteEntity* spriteStar = new SpriteEntity(
-                           ImageManager::getImageManager()->getImage(IMAGE_STAR_2),
+                           ImageManager::getInstance().getImage(IMAGE_STAR_2),
                             x, y);
   spriteStar->setScale(0.8f, 0.8f);
   spriteStar->setZ(z-1.0f);

--- a/src/BatEntity.cpp
+++ b/src/BatEntity.cpp
@@ -7,7 +7,7 @@
 #include "WitchBlastGame.h"
 
 BatEntity::BatEntity(float x, float y, bool invocated)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_BAT), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_BAT), x, y)
 {
   creatureSpeed = BAT_SPEED;
   velocity = Vector2D(creatureSpeed);

--- a/src/BlackRatEntity.cpp
+++ b/src/BlackRatEntity.cpp
@@ -8,7 +8,7 @@
 #include "WitchBlastGame.h"
 
 BlackRatEntity::BlackRatEntity(float x, float y, ratBlackTypeEnum ratType)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_RAT), x, y),
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_RAT), x, y),
   currentTile(0, 0),
   targetTile(0, 0)
 {
@@ -236,13 +236,13 @@ void BlackRatEntity::collideWithBolt(BoltEntity* boltEntity)
       float xs = (x + boltEntity->getX()) / 2;
       float ys = (y + boltEntity->getY()) / 2;
       boltEntity->collide();
-      SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+      SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
       star->setFading(true);
       star->setZ(y+ 100);
       star->setLifetime(0.7f);
       star->setType(ENTITY_EFFECT);
       star->setSpin(400.0f);
-      SoundManager::getSoundManager()->playSound(SOUND_CLANG_00);
+      SoundManager::getInstance().playSound(SOUND_CLANG_00);
     }
   }
   else EnemyEntity::collideWithBolt(boltEntity);

--- a/src/BoltEntity.cpp
+++ b/src/BoltEntity.cpp
@@ -7,7 +7,7 @@
 #include "sfml_game/SoundManager.h"
 
 BoltEntity::BoltEntity(float x, float y, float boltLifeTime, enumShotType boltType, int level)
-: CollidingSpriteEntity (ImageManager::getImageManager()->getImage(IMAGE_BOLT), x, y, BOLT_WIDTH, BOLT_HEIGHT)
+: CollidingSpriteEntity (ImageManager::getInstance().getImage(IMAGE_BOLT), x, y, BOLT_WIDTH, BOLT_HEIGHT)
 {
   lifetime = boltLifeTime;
   setDamages(INITIAL_BOLT_DAMAGES);
@@ -148,7 +148,7 @@ void BoltEntity::collide()
 
 void BoltEntity::generateParticule(Vector2D vel)
 {
-  SpriteEntity* trace = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BOLT), x, y, BOLT_WIDTH, BOLT_HEIGHT);
+  SpriteEntity* trace = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BOLT), x, y, BOLT_WIDTH, BOLT_HEIGHT);
   trace->setFading(true);
   trace->setZ(y);
   trace->setLifetime(0.5f);
@@ -196,7 +196,7 @@ void BoltEntity::onDying()
 
 void BoltEntity::stuck()
 {
-  SoundManager::getSoundManager()->playSound(SOUND_WALL_IMPACT);
+  SoundManager::getInstance().playSound(SOUND_WALL_IMPACT);
   if (boltType == ShotTypeBomb)
     explode();
   else
@@ -224,7 +224,7 @@ void BoltEntity::collideMapRight()
     velocity.x = 0.0f;
     isDying = true;
 
-    SoundManager::getSoundManager()->playSound(SOUND_WALL_IMPACT);
+    SoundManager::getInstance().playSound(SOUND_WALL_IMPACT);
     for (int i=0; i<5; i++)
     {
       Vector2D vel(100.0f + rand() % 150);
@@ -247,7 +247,7 @@ void BoltEntity::collideMapLeft()
     velocity.x = 0.0f;
     isDying = true;
 
-    SoundManager::getSoundManager()->playSound(SOUND_WALL_IMPACT);
+    SoundManager::getInstance().playSound(SOUND_WALL_IMPACT);
     for (int i=0; i<5; i++)
     {
       Vector2D vel(100.0f + rand() % 150);
@@ -270,7 +270,7 @@ void BoltEntity::collideMapTop()
     velocity.y = 0.0f;
     isDying = true;
 
-    SoundManager::getSoundManager()->playSound(SOUND_WALL_IMPACT);
+    SoundManager::getInstance().playSound(SOUND_WALL_IMPACT);
     for (int i=0; i<5; i++)
     {
       Vector2D vel(100.0f + rand() % 150);
@@ -293,7 +293,7 @@ void BoltEntity::collideMapBottom()
     velocity.y = 0.0f;
     isDying = true;
 
-    SoundManager::getSoundManager()->playSound(SOUND_WALL_IMPACT);
+    SoundManager::getInstance().playSound(SOUND_WALL_IMPACT);
     for (int i=0; i<5; i++)
     {
       Vector2D vel(100.0f + rand() % 150);
@@ -308,9 +308,9 @@ void BoltEntity::explode()
   isDying = true;
   new ExplosionEntity(x, y, 12);
   game().makeShake(0.5f);
-  SoundManager::getSoundManager()->playSound(SOUND_BOOM_00);
+  SoundManager::getInstance().playSound(SOUND_BOOM_00);
 
-  SpriteEntity* corpse= new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES), x, y, 64, 64);
+  SpriteEntity* corpse= new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES), x, y, 64, 64);
   corpse->setFrame(FRAME_CORPSE_SLIME_VIOLET);
   corpse->setImagesProLine(10);
   corpse->setZ(OFFSET_Y);

--- a/src/BubbleEntity.cpp
+++ b/src/BubbleEntity.cpp
@@ -8,7 +8,7 @@
 #include "WitchBlastGame.h"
 
 BubbleEntity::BubbleEntity(float x, float y, int bubbleSize)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_BUBBLE), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_BUBBLE), x, y)
 {
   this->bubbleSize = bubbleSize;
   imagesProLine = 8;
@@ -158,7 +158,7 @@ void BubbleEntity::dying()
 
   for (int i = 0; i < 5 - bubbleSize; i++)
   {
-    SpriteEntity* blood = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
+    SpriteEntity* blood = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
     blood->setZ(OFFSET_Y - 1);
 
     blood->setFrame(24 + rand()%6);
@@ -170,5 +170,5 @@ void BubbleEntity::dying()
     blood->setScale(bloodScale, bloodScale);
   }
 
-  SoundManager::getSoundManager()->playSound(SOUND_BUBBLE_00 + rand() % 2);
+  SoundManager::getInstance().playSound(SOUND_BUBBLE_00 + rand() % 2);
 }

--- a/src/ButcherEntity.cpp
+++ b/src/ButcherEntity.cpp
@@ -9,7 +9,7 @@
 #include "TextMapper.h"
 
 ButcherEntity::ButcherEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_BUTCHER), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_BUTCHER), x, y)
 {
   width = 128;
   height = 128;
@@ -53,9 +53,9 @@ void ButcherEntity::animate(float delay)
       timer = (rand() % 50) / 10.0f;
       setVelocity(Vector2D(x, y).vectorTo(game().getPlayerPosition(), creatureSpeed ));
       if (rand()%2 == 0)
-        SoundManager::getSoundManager()->playSound(SOUND_BUTCHER_00);
+        SoundManager::getInstance().playSound(SOUND_BUTCHER_00);
       else
-        SoundManager::getSoundManager()->playSound(SOUND_BUTCHER_01);
+        SoundManager::getInstance().playSound(SOUND_BUTCHER_01);
     }
 
     frame = ((int)(age * creatureSpeed / 25)) % 4;

--- a/src/CauldronEntity.cpp
+++ b/src/CauldronEntity.cpp
@@ -8,7 +8,7 @@
 #include "WitchBlastGame.h"
 
 CauldronEntity::CauldronEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_CAULDRON), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_CAULDRON), x, y)
 {
   creatureSpeed = 0.0f;
   velocity = Vector2D(0.0f, 0.0f);
@@ -31,7 +31,7 @@ CauldronEntity::CauldronEntity(float x, float y)
 
 void CauldronEntity::animate(float delay)
 {
-  SoundManager::getSoundManager()->playSound(SOUND_CAULDRON);
+  SoundManager::getInstance().playSound(SOUND_CAULDRON);
 
   invokeDelay -= delay;
   if (invokeDelay < 0.0f)
@@ -48,7 +48,7 @@ void CauldronEntity::animate(float delay)
     for (int i=0; i < 2; i++)
     {
       float xBub = x - 16 + rand() % 32;
-      SpriteEntity* bubble = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CAULDRON), xBub, y - 20, 8, 8);
+      SpriteEntity* bubble = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CAULDRON), xBub, y - 20, 8, 8);
       bubble->setZ(z);
       bubble->setFrame(32);
       bubble->setType(ENTITY_EFFECT);

--- a/src/ChestEntity.cpp
+++ b/src/ChestEntity.cpp
@@ -10,7 +10,7 @@
 #include <iostream>
 
 ChestEntity::ChestEntity(float x, float y, int chestType, bool isOpen)
-    : CollidingSpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CHEST), x, y, 48, 48)
+    : CollidingSpriteEntity(ImageManager::getInstance().getImage(IMAGE_CHEST), x, y, 48, 48)
 {
   type = ENTITY_CHEST;
   imagesProLine = 2;
@@ -48,7 +48,7 @@ void ChestEntity::animate(float delay)
     {
       initFallingGrid();
       for (int i = 0; i < 22; i++) fallRock();
-      SoundManager::getSoundManager()->playSound(SOUND_TRAP);
+      SoundManager::getInstance().playSound(SOUND_TRAP);
       game().makeShake(0.25f);
     }
   }
@@ -90,7 +90,7 @@ void ChestEntity::readCollidingEntity(CollidingSpriteEntity* entity)
 void ChestEntity::open()
 {
   isOpen = true;
-  SoundManager::getSoundManager()->playSound(SOUND_CHEST_OPENING);
+  SoundManager::getInstance().playSound(SOUND_CHEST_OPENING);
 
   if (chestType == CHEST_BASIC)
   {

--- a/src/CyclopsEntity.cpp
+++ b/src/CyclopsEntity.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 
 CyclopsEntity::CyclopsEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_CYCLOP), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_CYCLOP), x, y)
 {
   width = 128;
   height = 192;
@@ -59,7 +59,7 @@ int CyclopsEntity::getHealthLevel()
 void CyclopsEntity::fire()
 {
   new RockMissileEntity(x, y - 62, nextRockMissile);
-  SoundManager::getSoundManager()->playSound(SOUND_THROW);
+  SoundManager::getInstance().playSound(SOUND_THROW);
 }
 
 void CyclopsEntity::initFallingGrid()
@@ -123,7 +123,7 @@ void CyclopsEntity::computeStates(float delay)
           destroyLevel++;
           counter = destroyLevel + 1;
           timer = 0.9f;
-          SoundManager::getSoundManager()->playSound(SOUND_CYCLOP_00);
+          SoundManager::getInstance().playSound(SOUND_CYCLOP_00);
           initFallingGrid();
         }
         else
@@ -131,7 +131,7 @@ void CyclopsEntity::computeStates(float delay)
           state = 1; // charge to fire
           timer = 0.9f;
           counter = CYCLOP_NUMBER_ROCKS[getHealthLevel()];
-          SoundManager::getSoundManager()->playSound(SOUND_CYCLOP_00);
+          SoundManager::getInstance().playSound(SOUND_CYCLOP_00);
 
           computeNextRockMissile();
         }
@@ -164,7 +164,7 @@ void CyclopsEntity::computeStates(float delay)
       state = 4; // destroy
       timer = 0.2;
       game().makeShake(0.4f);
-      SoundManager::getSoundManager()->playSound(SOUND_WALL_IMPACT);
+      SoundManager::getInstance().playSound(SOUND_WALL_IMPACT);
       for (int i = 0; i < 10 ; i++) fallRock();
     }
     else if (state == 4)
@@ -199,12 +199,12 @@ void CyclopsEntity::animate(float delay)
     {
       isDying = true;
       SpriteEntity* corpse;
-      corpse = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES_BIG), x, y, 128, 128);
+      corpse = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES_BIG), x, y, 128, 128);
       corpse->setFrame(deathFrame - FRAME_CORPSE_KING_RAT);
 
       corpse->setZ(OFFSET_Y);
       corpse->setType(ENTITY_CORPSE);
-      if (dyingSound != SOUND_NONE) SoundManager::getSoundManager()->playSound(dyingSound);
+      if (dyingSound != SOUND_NONE) SoundManager::getInstance().playSound(dyingSound);
     }
     else
     {

--- a/src/DoorEntity.cpp
+++ b/src/DoorEntity.cpp
@@ -2,7 +2,7 @@
 #include "Constants.h"
 #include "sfml_game/ImageManager.h"
 
-DoorEntity::DoorEntity(int direction) : SpriteEntity (ImageManager::getImageManager()->getImage(IMAGE_DOOR))
+DoorEntity::DoorEntity(int direction) : SpriteEntity (ImageManager::getInstance().getImage(IMAGE_DOOR))
 {
   this->direction = direction;
   isOpen = true;

--- a/src/DungeonMap.cpp
+++ b/src/DungeonMap.cpp
@@ -697,7 +697,7 @@ void DungeonMap::restoreSprites()
 
     if (ilm.type == ENTITY_BLOOD)
     {
-      SpriteEntity* blood = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BLOOD), ilm.x, ilm.y, 16, 16, 6);
+      SpriteEntity* blood = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BLOOD), ilm.x, ilm.y, 16, 16, 6);
       blood->setZ(OFFSET_Y - 1);
       blood->setFrame(ilm.frame);
       blood->setType(ENTITY_BLOOD);
@@ -709,12 +709,12 @@ void DungeonMap::restoreSprites()
 
       if (ilm.frame >= FRAME_CORPSE_KING_RAT)
       {
-        corpse = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES_BIG), ilm.x, ilm.y, 128, 128);
+        corpse = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES_BIG), ilm.x, ilm.y, 128, 128);
         corpse->setFrame(ilm.frame - FRAME_CORPSE_KING_RAT);
       }
       else
       {
-        corpse = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES), ilm.x, ilm.y, 64, 64);
+        corpse = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES), ilm.x, ilm.y, 64, 64);
         corpse->setFrame(ilm.frame);
         corpse->setImagesProLine(10);
       }

--- a/src/EnemyEntity.cpp
+++ b/src/EnemyEntity.cpp
@@ -45,19 +45,19 @@ void EnemyEntity::animate(float delay)
       SpriteEntity* corpse;
       if (deathFrame >= FRAME_CORPSE_KING_RAT)
       {
-        corpse = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES_BIG), x, y, 128, 128);
+        corpse = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES_BIG), x, y, 128, 128);
         corpse->setFrame(deathFrame - FRAME_CORPSE_KING_RAT);
       }
       else
       {
-        corpse = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES), x, y, 64, 64);
+        corpse = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES), x, y, 64, 64);
         corpse->setFrame(deathFrame);
         corpse->setImagesProLine(10);
       }
 
       corpse->setZ(OFFSET_Y);
       corpse->setType(ENTITY_CORPSE);
-      if (dyingSound != SOUND_NONE) SoundManager::getSoundManager()->playSound(dyingSound);
+      if (dyingSound != SOUND_NONE) SoundManager::getInstance().playSound(dyingSound);
     }
     else
     {
@@ -119,7 +119,7 @@ void EnemyEntity::readCollidingEntity(CollidingSpriteEntity* entity)
         {
           float xs = (x + playerEntity->getX()) / 2;
           float ys = (y + playerEntity->getY()) / 2;
-          SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+          SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
           star->setFading(true);
           star->setZ(y+ 100);
           star->setLifetime(0.7f);
@@ -157,9 +157,9 @@ void EnemyEntity::collideWithBolt(BoltEntity* boltEntity)
 
   hurt(boltEntity->getDamages(), boltEntity->getBoltType(), boltEntity->getLevel(), boltEntity->isCritical());
   if (bloodColor > BloodNone) game().generateBlood(x, y, bloodColor);
-  SoundManager::getSoundManager()->playSound(SOUND_IMPACT);
+  SoundManager::getInstance().playSound(SOUND_IMPACT);
 
-  SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+  SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
   star->setFading(true);
   star->setZ(y+ 100);
   star->setLifetime(0.7f);
@@ -226,7 +226,7 @@ bool EnemyEntity::hurt(int damages, enumShotType hurtingType, int level, bool cr
 {
   bool hurted = BaseCreatureEntity::hurt(damages, hurtingType, level, critical);
   if (hurted && hurtingSound != SOUND_NONE && hp > 0)
-    SoundManager::getSoundManager()->playSound(hurtingSound);
+    SoundManager::getInstance().playSound(hurtingSound);
   return hurted;
 }
 
@@ -235,18 +235,18 @@ void EnemyEntity::dying()
   if (dyingFrame == -1)
   {
     isDying = true;
-    SpriteEntity* corpse = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES), x, y, 64, 64);
+    SpriteEntity* corpse = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES), x, y, 64, 64);
     corpse->setZ(OFFSET_Y);
     corpse->setImagesProLine(10);
     corpse->setFrame(deathFrame);
     corpse->setType(ENTITY_CORPSE);
-    if (dyingSound != SOUND_NONE) SoundManager::getSoundManager()->playSound(dyingSound);
+    if (dyingSound != SOUND_NONE) SoundManager::getInstance().playSound(dyingSound);
   }
   else
   {
     isAgonising = true;
     hVelocity = 200.0f;
-    if (agonizingSound != SOUND_NONE) SoundManager::getSoundManager()->playSound(agonizingSound);
+    if (agonizingSound != SOUND_NONE) SoundManager::getInstance().playSound(agonizingSound);
   }
   if (bloodColor != BloodNone) for (int i = 0; i < 4; i++) game().generateBlood(x, y, bloodColor);
   drop();

--- a/src/EnnemyBoltEntity.cpp
+++ b/src/EnnemyBoltEntity.cpp
@@ -23,7 +23,7 @@ void EnnemyBoltEntity::animate(float delay)
 {
   if (boltType != ShotTypeBomb)
   {
-    SpriteEntity* trace = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BOLT), x, y, BOLT_WIDTH, BOLT_HEIGHT);
+    SpriteEntity* trace = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BOLT), x, y, BOLT_WIDTH, BOLT_HEIGHT);
     trace->setFading(true);
     trace->setZ(y);
     trace->setLifetime(0.2f);

--- a/src/EvilFlowerEntity.cpp
+++ b/src/EvilFlowerEntity.cpp
@@ -10,7 +10,7 @@
 #include <math.h>
 
 EvilFlowerEntity::EvilFlowerEntity(float x, float y)
-    : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_FLOWER), x, y)
+    : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_FLOWER), x, y)
 {
   hp = EVIL_FLOWER_HP;
   meleeDamages = EVIL_FLOWER_MELEE_DAMAGES;
@@ -61,19 +61,19 @@ void EvilFlowerEntity::dying()
 {
   isDying = true;
   game().addKilledEnemy(enemyType);
-  SpriteEntity* deadFlower = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES), x, y, 64, 64);
+  SpriteEntity* deadFlower = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES), x, y, 64, 64);
   deadFlower->setZ(OFFSET_Y);
   deadFlower->setFrame(FRAME_CORPSE_FLOWER);
   deadFlower->setType(ENTITY_CORPSE);
 
   for (int i = 0; i < 4; i++) game().generateBlood(x, y, bloodColor);
   drop();
-  SoundManager::getSoundManager()->playSound(SOUND_ENNEMY_DYING);
+  SoundManager::getInstance().playSound(SOUND_ENNEMY_DYING);
 }
 
 void EvilFlowerEntity::fire()
 {
-    SoundManager::getSoundManager()->playSound(SOUND_BLAST_FLOWER);
+    SoundManager::getInstance().playSound(SOUND_BLAST_FLOWER);
     EnnemyBoltEntity* bolt = new EnnemyBoltEntity
           (x, y + 10, ShotTypeStandard, 0);
     bolt->setFrame(1);

--- a/src/ExplosionEntity.cpp
+++ b/src/ExplosionEntity.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 ExplosionEntity::ExplosionEntity(float x, float y, int damage)
-  : SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_EXPLOSION64), x, y, 100, 100)
+  : SpriteEntity(ImageManager::getInstance().getImage(IMAGE_EXPLOSION64), x, y, 100, 100)
 {
   type = ENTITY_EXPLOSION;
   frame = 0;
@@ -54,7 +54,7 @@ void ExplosionEntity::dying()
 
 void ExplosionEntity::testCollisions()
 {
-  EntityManager::EntityList* entityList =EntityManager::getEntityManager()->getList();
+  EntityManager::EntityList* entityList =EntityManager::getInstance().getList();
   EntityManager::EntityList::iterator it;
 
 	for (it = entityList->begin (); it != entityList->end ();)

--- a/src/FairyEntity.cpp
+++ b/src/FairyEntity.cpp
@@ -7,7 +7,7 @@
 #include "sfml_game/MyTools.h"
 #include <iostream>
 
-FairyEntity::FairyEntity(float x, float y, enumFamiliar fairyType) : SpriteEntity (ImageManager::getImageManager()->getImage(IMAGE_FAIRY), x, y, 48, 72)
+FairyEntity::FairyEntity(float x, float y, enumFamiliar fairyType) : SpriteEntity (ImageManager::getInstance().getImage(IMAGE_FAIRY), x, y, 48, 72)
 {
   this->x = x;
   this->y = y;
@@ -123,7 +123,7 @@ void FairyEntity::fire(int dir)
 
   if (fireDelay <= 0.0f)
   {
-    SoundManager::getSoundManager()->playSound(SOUND_BLAST_STANDARD);
+    SoundManager::getInstance().playSound(SOUND_BLAST_STANDARD);
     fireDelay = fairyFireDelay;
 
     float velx = 0.0f;
@@ -201,7 +201,7 @@ void FairyEntity::tryToFire()
         bolt->setFlying(true);
         bolt->setVelocity(Vector2D(x, y).vectorTo(target, FAIRY_BOLT_VELOCITY));
 
-        SoundManager::getSoundManager()->playSound(SOUND_BLAST_STANDARD);
+        SoundManager::getInstance().playSound(SOUND_BLAST_STANDARD);
         fireDelay = fairyFireDelay;
 
         if ((target.x - x) * (target.x - x) > (target.y - y) *(target.y - y))

--- a/src/FallingRockEntity.cpp
+++ b/src/FallingRockEntity.cpp
@@ -7,7 +7,7 @@
 #include "WitchBlastGame.h"
 
 FallingRockEntity::FallingRockEntity(float x, float y, int rockType)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_CYCLOP), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_CYCLOP), x, y)
 {
   imagesProLine = 20;
   type = ENTITY_ENNEMY;
@@ -103,12 +103,12 @@ void FallingRockEntity::dying()
 {
   isDying = true;
   game().addKilledEnemy(enemyType);
-  SoundManager::getSoundManager()->playSound(SOUND_ROCK_IMPACT);
+  SoundManager::getInstance().playSound(SOUND_ROCK_IMPACT);
   game().makeShake(0.1f);
 
   for (int i = 0; i < 4; i++)
   {
-    SpriteEntity* blood = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
+    SpriteEntity* blood = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
     blood->setZ(OFFSET_Y - 1);
 
     blood->setFrame(12 + rand()%6);

--- a/src/GiantSlimeEntity.cpp
+++ b/src/GiantSlimeEntity.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 
 GiantSlimeEntity::GiantSlimeEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_GIANT_SLIME), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_GIANT_SLIME), x, y)
 {
   width = 128;
   height = 128;
@@ -67,7 +67,7 @@ void GiantSlimeEntity::changeToState(int n)
 
     viscosity = 0.991f;
 
-    SoundManager::getSoundManager()->playSound(SOUND_SLIME_JUMP);
+    SoundManager::getInstance().playSound(SOUND_SLIME_JUMP);
     hVelocity = 420.0f + rand() % 380;
 
     isFirstJumping = true;
@@ -107,7 +107,7 @@ void GiantSlimeEntity::changeToState(int n)
 
     viscosity = 1.0f;
 
-    SoundManager::getSoundManager()->playSound(SOUND_SLIME_JUMP);
+    SoundManager::getInstance().playSound(SOUND_SLIME_JUMP);
     hVelocity = 1200.0f;
   }
   else if (n == 7) // falling
@@ -247,11 +247,11 @@ void GiantSlimeEntity::animate(float delay)
         {
           isFirstJumping = false;
           hVelocity = 160.0f;
-          SoundManager::getSoundManager()->playSound(SOUND_SLIME_IMAPCT);
+          SoundManager::getInstance().playSound(SOUND_SLIME_IMAPCT);
         }
         else
         {
-          SoundManager::getSoundManager()->playSound(SOUND_SLIME_IMAPCT_WEAK);
+          SoundManager::getInstance().playSound(SOUND_SLIME_IMAPCT_WEAK);
           viscosity = 0.96f;
           changeToState(0);
         }
@@ -294,7 +294,7 @@ void GiantSlimeEntity::animate(float delay)
         h = 0;
         changeToState(8);
         game().makeShake(0.8f);
-        SoundManager::getSoundManager()->playSound(SOUND_WALL_IMPACT);
+        SoundManager::getInstance().playSound(SOUND_WALL_IMPACT);
       }
     }
   }
@@ -349,7 +349,7 @@ void GiantSlimeEntity::dying()
 {
   isDying = true;
   game().addKilledEnemy(enemyType);
-  SpriteEntity* deadRat = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES_BIG), x, y, 128, 128);
+  SpriteEntity* deadRat = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES_BIG), x, y, 128, 128);
   deadRat->setZ(OFFSET_Y);
   deadRat->setFrame(FRAME_CORPSE_GIANT_SLIME - FRAME_CORPSE_KING_RAT);
   deadRat->setType(ENTITY_CORPSE);
@@ -369,13 +369,13 @@ void GiantSlimeEntity::dying()
   }
 
   game().makeShake(1.0f);
-  SoundManager::getSoundManager()->playSound(SOUND_SLIME_SMASH);
+  SoundManager::getInstance().playSound(SOUND_SLIME_SMASH);
 
   ItemEntity* newItem = new ItemEntity(ItemBossHeart, x, y);
   newItem->setVelocity(Vector2D(100.0f + rand()% 250));
   newItem->setViscosity(0.96f);
 
-  SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_GIANT_SLIME), x, y, 128, 128, 8);
+  SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_GIANT_SLIME), x, y, 128, 128, 8);
   star->setFrame(4);
   star->setFading(true);
   star->setZ(y+ 100);
@@ -458,7 +458,7 @@ BaseCreatureEntity::enumMovingStyle GiantSlimeEntity::getMovingStyle()
 
 void GiantSlimeEntity::fire()
 {
-    SoundManager::getSoundManager()->playSound(SOUND_BLAST_FLOWER);
+    SoundManager::getInstance().playSound(SOUND_BLAST_FLOWER);
     EnnemyBoltEntity* bolt = new EnnemyBoltEntity
           (x, y + 10, ShotTypeStandard, 0);
     bolt->setFrame(1);

--- a/src/GiantSpiderEntity.cpp
+++ b/src/GiantSpiderEntity.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 
 GiantSpiderEntity::GiantSpiderEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_GIANT_SPIDER), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_GIANT_SPIDER), x, y)
 {
   width = 128;
   height = 128;
@@ -83,14 +83,14 @@ void GiantSpiderEntity::animate(float delay)
       if (walkingSoundDelay <= 0.0f)
       {
         walkingSoundDelay = 1.0f;
-        SoundManager::getSoundManager()->playSound(SOUND_SPIDER_WALKING);
+        SoundManager::getInstance().playSound(SOUND_SPIDER_WALKING);
       }
       fireDelay -= delay;
       if (fireDelay <= 0.0f)
       {
         if (rand() % 12 == 0)
         {
-          SoundManager::getSoundManager()->playSound(SOUND_SPIDER_WEB);
+          SoundManager::getInstance().playSound(SOUND_SPIDER_WEB);
           for (int i = 0; i < 3; i++) new SpiderWebEntity(x, y);
         }
         else
@@ -110,7 +110,7 @@ void GiantSpiderEntity::animate(float delay)
         velocity = Vector2D(0.0f, 0.0f);
         timer = 1.0f;
         creatureSpeed = GIANT_SPIDER_SPEED[hurtLevel];
-        SoundManager::getSoundManager()->playSound(SOUND_SPIDER_HURT);
+        SoundManager::getInstance().playSound(SOUND_SPIDER_HURT);
       }
     }
     else if (state == 3) // wait after falling
@@ -298,7 +298,7 @@ bool GiantSpiderEntity::canCollide()
 
 void GiantSpiderEntity::fire(int fireType)
 {
-    SoundManager::getSoundManager()->playSound(SOUND_BLAST_FLOWER);
+    SoundManager::getInstance().playSound(SOUND_BLAST_FLOWER);
 
     EnnemyBoltEntity* bolt;
 
@@ -325,7 +325,7 @@ void GiantSpiderEntity::drop()
   newItem->setVelocity(Vector2D(100.0f + rand()% 250));
   newItem->setViscosity(0.96f);
 
-  EntityManager::EntityList* entityList =EntityManager::getEntityManager()->getList();
+  EntityManager::EntityList* entityList = EntityManager::getInstance().getList();
   EntityManager::EntityList::iterator it;
 
 	for (it = entityList->begin (); it != entityList->end ();)

--- a/src/GreenRatEntity.cpp
+++ b/src/GreenRatEntity.cpp
@@ -8,7 +8,7 @@
 #include "WitchBlastGame.h"
 
 GreenRatEntity::GreenRatEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_RAT), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_RAT), x, y)
 {
   imagesProLine = 8;
   creatureSpeed = GREEN_RAT_SPEED;

--- a/src/ImpEntity.cpp
+++ b/src/ImpEntity.cpp
@@ -8,7 +8,7 @@
 #include "EnnemyBoltEntity.h"
 
 ImpEntity::ImpEntity(float x, float y, impTypeEnum impType)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_IMP), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_IMP), x, y)
 {
   // general
   creatureSpeed = IMP_SPEED;
@@ -161,7 +161,7 @@ void ImpEntity::dying()
 
 void ImpEntity::fire()
 {
-    SoundManager::getSoundManager()->playSound(SOUND_BLAST_FLOWER);
+    SoundManager::getInstance().playSound(SOUND_BLAST_FLOWER);
 
     EnnemyBoltEntity* bolt;
     if (impType == ImpTypeBlue)

--- a/src/ItemEntity.cpp
+++ b/src/ItemEntity.cpp
@@ -9,7 +9,7 @@
 #include <sstream>
 
 ItemEntity::ItemEntity(enumItemType itemType, float x, float y)
-  : CollidingSpriteEntity(ImageManager::getImageManager()->getImage(itemType >= FirstEquipItem ? IMAGE_ITEMS_EQUIP : IMAGE_ITEMS), x, y, ITEM_WIDTH, ITEM_HEIGHT)
+  : CollidingSpriteEntity(ImageManager::getInstance().getImage(itemType >= FirstEquipItem ? IMAGE_ITEMS_EQUIP : IMAGE_ITEMS), x, y, ITEM_WIDTH, ITEM_HEIGHT)
 {
   type = ENTITY_ITEM;
   this->itemType = itemType;
@@ -92,7 +92,7 @@ void ItemEntity::animate(float delay)
     if (timer <= 0.0f)
     {
       timer = HEART_BEAT_DELAY;
-      SoundManager::getSoundManager()->playSound(SOUND_HEART);
+      SoundManager::getInstance().playSound(SOUND_HEART);
     }
     float sc;
     if (timer > HEART_BEAT_DELAY - 0.25f)

--- a/src/KingRatEntity.cpp
+++ b/src/KingRatEntity.cpp
@@ -12,7 +12,7 @@
 #include <iostream>
 
 KingRatEntity::KingRatEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_KING_RAT), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_KING_RAT), x, y)
 {
   width = 128;
   height = 128;
@@ -61,12 +61,12 @@ void KingRatEntity::animate(float delay)
     {
       isDying = true;
       SpriteEntity* corpse;
-      corpse = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES_BIG), x, y + 48, 128, 128);
+      corpse = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES_BIG), x, y + 48, 128, 128);
       corpse->setFrame(deathFrame - FRAME_CORPSE_KING_RAT);
 
       corpse->setZ(OFFSET_Y);
       corpse->setType(ENTITY_CORPSE);
-      if (dyingSound != SOUND_NONE) SoundManager::getSoundManager()->playSound(dyingSound);
+      if (dyingSound != SOUND_NONE) SoundManager::getInstance().playSound(dyingSound);
     }
     else
     {
@@ -119,7 +119,7 @@ void KingRatEntity::animate(float delay)
       state = 1;
       // generate rats
       generateGreenRats();
-      SoundManager::getSoundManager()->playSound(SOUND_KING_RAT_1);
+      SoundManager::getInstance().playSound(SOUND_KING_RAT_1);
       timer = 2.0f;
 
       velocity.x = 0.0f;
@@ -135,7 +135,7 @@ void KingRatEntity::animate(float delay)
         timer = 12.0f;
         state = 6;
         velocity = Vector2D(KING_RAT_BERSERK_SPEED);
-        SoundManager::getSoundManager()->playSound(SOUND_KING_RAT_2);
+        SoundManager::getInstance().playSound(SOUND_KING_RAT_2);
       }
       else
       {
@@ -153,7 +153,7 @@ void KingRatEntity::animate(float delay)
 
       velocity.x = 0.0f;
       velocity.y = 0.0f;
-      SoundManager::getSoundManager()->playSound(SOUND_KING_RAT_2);
+      SoundManager::getInstance().playSound(SOUND_KING_RAT_2);
     }
 
     else if (state == 3) // normal -> rush
@@ -181,7 +181,7 @@ void KingRatEntity::animate(float delay)
         timer = 12.0f;
         state = 6;
         velocity = Vector2D(KING_RAT_BERSERK_SPEED);
-        SoundManager::getSoundManager()->playSound(SOUND_KING_RAT_2);
+        SoundManager::getInstance().playSound(SOUND_KING_RAT_2);
       }
       else
       {
@@ -206,7 +206,7 @@ void KingRatEntity::animate(float delay)
     if (berserkDelay <= 0.0f)
     {
       berserkDelay = 0.8f + (rand()%10) / 10.0f;
-      SoundManager::getSoundManager()->playSound(SOUND_KING_RAT_2);
+      SoundManager::getInstance().playSound(SOUND_KING_RAT_2);
 
       setVelocity(Vector2D(x, y).vectorTo(game().getPlayerPosition(),KING_RAT_BERSERK_SPEED ));
     }
@@ -273,7 +273,7 @@ void KingRatEntity::afterWallCollide()
       velocity.x *= 0.75f;
       velocity.y *= 0.75f;
 
-      SoundManager::getSoundManager()->playSound(SOUND_BIG_WALL_IMPACT);
+      SoundManager::getInstance().playSound(SOUND_BIG_WALL_IMPACT);
       game().makeShake(0.75f);
     }
 }

--- a/src/LittleSpiderEntity.cpp
+++ b/src/LittleSpiderEntity.cpp
@@ -8,7 +8,7 @@
 #include "WitchBlastGame.h"
 
 LittleSpiderEntity::LittleSpiderEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_LITTLE_SPIDER), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_LITTLE_SPIDER), x, y)
 {
   imagesProLine = 8;
   creatureSpeed = 175.0f;

--- a/src/MagnetEntity.cpp
+++ b/src/MagnetEntity.cpp
@@ -2,7 +2,7 @@
 #include "Constants.h"
 #include "sfml_game/ImageManager.h"
 
-MagnetEntity::MagnetEntity(float x, float y, PlayerEntity* parentEntity, enumItemType itemType) : SpriteEntity (ImageManager::getImageManager()->getImage(IMAGE_ITEMS), x, y, ITEM_WIDTH, ITEM_HEIGHT)
+MagnetEntity::MagnetEntity(float x, float y, PlayerEntity* parentEntity, enumItemType itemType) : SpriteEntity (ImageManager::getInstance().getImage(IMAGE_ITEMS), x, y, ITEM_WIDTH, ITEM_HEIGHT)
 {
   this->x = x;
   this->y = y;

--- a/src/ParticleGenerator.cpp
+++ b/src/ParticleGenerator.cpp
@@ -64,7 +64,7 @@ void ParticleGenerator::GenerateBoltParticle(int frame, const Vector2D & velocit
   // "background" particle
   if (frame != ShotTypeIce && frame != ShotTypeIllusion)
   {
-    SpriteEntity* particle = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BOLT), posX, posY, BOLT_WIDTH, BOLT_HEIGHT);
+    SpriteEntity* particle = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BOLT), posX, posY, BOLT_WIDTH, BOLT_HEIGHT);
     particle->setFading(true);
     particle->setImagesProLine(BOLT_PRO_LINE);
     particle->setZ(10);
@@ -78,7 +78,7 @@ void ParticleGenerator::GenerateBoltParticle(int frame, const Vector2D & velocit
   // "blend" particle
   particleScale -= 0.1f;
 
-  SpriteEntity* particle = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BOLT), posX, posY, BOLT_WIDTH, BOLT_HEIGHT);
+  SpriteEntity* particle = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BOLT), posX, posY, BOLT_WIDTH, BOLT_HEIGHT);
   particle->setFading(true);
   particle->setImagesProLine(BOLT_PRO_LINE);
   particle->setZ(11);

--- a/src/PlayerEntity.cpp
+++ b/src/PlayerEntity.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 
 PlayerEntity::PlayerEntity(float x, float y)
-  : BaseCreatureEntity (ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE), x, y, 80, 128)
+  : BaseCreatureEntity (ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE), x, y, 80, 128)
 {
   currentFireDelay = -1.0f;
   invincibleDelay = -1.0f;
@@ -140,7 +140,7 @@ void PlayerEntity::pay(int price)
 {
   gold -= price;
   if (gold < 0) gold = 0;
-  SoundManager::getSoundManager()->playSound(SOUND_PAY);
+  SoundManager::getInstance().playSound(SOUND_PAY);
 }
 
 void PlayerEntity::acquireItemAfterStance()
@@ -172,7 +172,7 @@ void PlayerEntity::acquireItemAfterStance()
       hp += hpBonus;
       hpDisplay += hpBonus;
 
-      SoundManager::getSoundManager()->playSound(SOUND_EAT);
+      SoundManager::getInstance().playSound(SOUND_EAT);
 
       std::ostringstream oss;
       oss << "HP Max +" << hpBonus;
@@ -190,7 +190,7 @@ void PlayerEntity::acquireItemAfterStance()
       hpMax += 1;
       hp = hpMax;
 
-      SoundManager::getSoundManager()->playSound(SOUND_EAT);
+      SoundManager::getInstance().playSound(SOUND_EAT);
 
       TextEntity* text = new TextEntity("HP Max + 1", 15, x, y - 50.0f);
       text->setColor(TextEntity::COLOR_FADING_GREEN);
@@ -215,7 +215,7 @@ void PlayerEntity::animate(float delay)
     specialBoltTimer -= delay;
     if (specialBoltTimer <= 0.0f)
     {
-      if (getShotType() == ShotTypeIce) SoundManager::getSoundManager()->playSound(SOUND_ICE_CHARGE);
+      if (getShotType() == ShotTypeIce) SoundManager::getInstance().playSound(SOUND_ICE_CHARGE);
     }
   }
   // rate of fire
@@ -320,80 +320,80 @@ void PlayerEntity::renderHead(sf::RenderTarget* app)
 
     if (equip[EQUIP_ENCHANTER_HAT])
     {
-      sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_EQUIP));
+      sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_EQUIP));
       if (playerStatus == playerStatusAcquire || playerStatus == playerStatusUnlocking)
         sprite.setTextureRect(sf::IntRect( 0, 0, width, height));
       else
         sprite.setTextureRect(sf::IntRect( (frame / 3 + spriteDx) * width, 0, width, height));
       app->draw(sprite);
-      sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE));
+      sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE));
     }
   }
 }
 
 void PlayerEntity::renderBody(sf::RenderTarget* app)
 {
-  if (equip[EQUIP_MAGICIAN_ROBE]) sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_EQUIP));
+  if (equip[EQUIP_MAGICIAN_ROBE]) sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_EQUIP));
   sprite.setTextureRect(sf::IntRect( (frame + spriteDx) * width, height, width, height));
   app->draw(sprite);
-  sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE));
+  sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE));
 
   if (equip[EQUIP_CONCENTRATION_AMULET] && playerStatus != playerStatusDead)
   {
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_COLLAR));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_COLLAR));
     if (playerStatus == playerStatusAcquire || playerStatus == playerStatusUnlocking)
       sprite.setTextureRect(sf::IntRect( 0, 0, width, height));
     else
       sprite.setTextureRect(sf::IntRect( (spriteDx / 3) * width, 0, width, height));
 
     app->draw(sprite);
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE));
   }
 
   if (equip[EQUIP_LEATHER_BELT] && playerStatus != playerStatusDead)
   {
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_EQUIP));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_EQUIP));
     sprite.setTextureRect(sf::IntRect( (frame + spriteDx) * width, height * 5, width, height));
     app->draw(sprite);
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE));
   }
 
   if (equip[EQUIP_BROOCH_STAR])
   {
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_EQUIP));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_EQUIP));
     sprite.setTextureRect(sf::IntRect( (14 + spriteDx / 3) * width, 2 * height, width, height));
     app->draw(sprite);
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE));
   }
 }
 
 void PlayerEntity::renderHands(sf::RenderTarget* app)
 {
   if (equip[EQUIP_VIBRATION_GLOVES] && playerStatus != playerStatusDead)
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_EQUIP));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_EQUIP));
 
   sprite.setTextureRect(sf::IntRect( (frame + spriteDx) * width, height * 3, width, height));
   app->draw(sprite);
 
-  sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE));
+  sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE));
 }
 
 void PlayerEntity::renderFeet(sf::RenderTarget* app)
 {
   if (equip[EQUIP_LEATHER_BOOTS] && playerStatus != playerStatusDead)
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_EQUIP));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_EQUIP));
 
   sprite.setTextureRect(sf::IntRect( (frame + spriteDx) * width, height * 2, width, height));
   app->draw(sprite);
 
-  sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE));
+  sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE));
 }
 
 void PlayerEntity::renderStaff(sf::RenderTarget* app)
 {
   if (playerStatus == playerStatusDead) return;
 
-  if (equip[EQUIP_MAHOGANY_STAFF]) sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_EQUIP));
+  if (equip[EQUIP_MAHOGANY_STAFF]) sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_EQUIP));
   int xSnake, ySnake;
   int xStone, yStone;
 
@@ -427,11 +427,11 @@ void PlayerEntity::renderStaff(sf::RenderTarget* app)
 
   if (equip[EQUIP_BLOOD_SNAKE])
   {
-    sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_EQUIP));
+    sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_EQUIP));
     sprite.setTextureRect(sf::IntRect( xSnake, ySnake, width, height));
     app->draw(sprite);
   }
-  sprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE));
+  sprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE));
   if (getShotType() != ShotTypeStandard)
   {
     sf::Color savedColor = sprite.getColor();
@@ -603,7 +603,7 @@ void PlayerEntity::readCollidingEntity(CollidingSpriteEntity* entity)
 
       float xs = (x + boltEntity->getX()) / 2;
       float ys = (y + boltEntity->getY()) / 2;
-      SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+      SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
       star->setFading(true);
       star->setZ(y+ 100);
       star->setLifetime(0.7f);
@@ -764,7 +764,7 @@ void PlayerEntity::rageFire()
         bolt->setVelocity(Vector2D(velx, vely));
       }
     }
-  SoundManager::getSoundManager()->playSound(SOUND_BLAST_STANDARD);
+  SoundManager::getInstance().playSound(SOUND_BLAST_STANDARD);
 }
 
 void PlayerEntity::resestFireDirection()
@@ -787,7 +787,7 @@ void PlayerEntity::fire(int direction)
 
   if (canFirePlayer && playerStatus != playerStatusDead && playerStatus != playerStatusAcquire)
   {
-    SoundManager::getSoundManager()->playSound(SOUND_BLAST_STANDARD);
+    SoundManager::getInstance().playSound(SOUND_BLAST_STANDARD);
 
     if (equip[EQUIP_BOOK_DUAL] || equip[EQUIP_BOOK_TRIPLE])
     {
@@ -883,7 +883,7 @@ bool PlayerEntity::hurt(int damages, enumShotType hurtingType, int level, bool c
 
   if (invincibleDelay <= 0.0f || hurtingType == ShotTypeDeterministic)
   {
-    SoundManager::getSoundManager()->playSound(SOUND_PLAYER_HIT);
+    SoundManager::getInstance().playSound(SOUND_PLAYER_HIT);
     if (BaseCreatureEntity::hurt(damages, hurtingType, level, critical))
     {
       if (hurtingType != ShotTypeDeterministic)
@@ -905,7 +905,7 @@ bool PlayerEntity::hurt(int damages, enumShotType hurtingType, int level, bool c
 void PlayerEntity::loseItem(enumItemType itemType, bool isEquip)
 {
   CollidingSpriteEntity* itemSprite
-    = new CollidingSpriteEntity(ImageManager::getImageManager()->getImage(isEquip ? IMAGE_ITEMS_EQUIP : IMAGE_ITEMS), x, y, 32, 32);
+    = new CollidingSpriteEntity(ImageManager::getInstance().getImage(isEquip ? IMAGE_ITEMS_EQUIP : IMAGE_ITEMS), x, y, 32, 32);
   itemSprite->setMap(map, TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
   itemSprite->setZ(OFFSET_Y - 1);
   itemSprite->setFrame(itemType);
@@ -921,7 +921,7 @@ void PlayerEntity::dying()
   playerStatus = playerStatusDead;
   deathAge = 0.0f;
   hp = 0;
-  SoundManager::getSoundManager()->playSound(SOUND_PLAYER_DIE);
+  SoundManager::getInstance().playSound(SOUND_PLAYER_DIE);
   setVelocity(Vector2D(0.0f, 0.0f));
 
   int i;
@@ -941,7 +941,7 @@ void PlayerEntity::dying()
   for (i = 0; i < 8; i++) game().generateBlood(x, y, bloodColor);
 
   CollidingSpriteEntity* itemSprite
-    = new CollidingSpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_PLAYER_BASE), x, y, 80, 120);
+    = new CollidingSpriteEntity(ImageManager::getInstance().getImage(IMAGE_PLAYER_BASE), x, y, 80, 120);
   itemSprite->setMap(map, TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
   itemSprite->setZ(OFFSET_Y - 1);
   itemSprite->setImagesProLine(14);
@@ -974,31 +974,31 @@ void PlayerEntity::acquireItem(enumItemType type)
     case ItemCopperCoin:
       gold++;
       displayAcquiredGold(1);
-      SoundManager::getSoundManager()->playSound(SOUND_COIN_PICK_UP);
+      SoundManager::getInstance().playSound(SOUND_COIN_PICK_UP);
       break;
     case ItemSilverCoin:
       gold = gold + 5;
       displayAcquiredGold(5);
-      SoundManager::getSoundManager()->playSound(SOUND_COIN_PICK_UP);
+      SoundManager::getInstance().playSound(SOUND_COIN_PICK_UP);
       break;
     case ItemGoldCoin:
       gold = gold + 10;
       displayAcquiredGold(10);
-      SoundManager::getSoundManager()->playSound(SOUND_COIN_PICK_UP);
+      SoundManager::getInstance().playSound(SOUND_COIN_PICK_UP);
       break;
     case ItemHealthVerySmall:
       hp += 3;
-      SoundManager::getSoundManager()->playSound(SOUND_EAT);
+      SoundManager::getInstance().playSound(SOUND_EAT);
       if (hp > hpMax) hp = hpMax;
       break;
     case ItemHealthSmall:
       hp += 7;
-      SoundManager::getSoundManager()->playSound(SOUND_EAT);
+      SoundManager::getInstance().playSound(SOUND_EAT);
       if (hp > hpMax) hp = hpMax;
       break;
     case ItemHealth:
       hp += 15;
-      SoundManager::getSoundManager()->playSound(SOUND_EAT);
+      SoundManager::getInstance().playSound(SOUND_EAT);
       if (hp > hpMax) hp = hpMax;
       break;
     default:
@@ -1064,7 +1064,7 @@ void PlayerEntity::acquireStance(enumItemType type)
   playerStatus = playerStatusAcquire;
   acquireDelay = ACQUIRE_DELAY;
   acquiredItem = (enumItemType)(type);
-  SoundManager::getSoundManager()->playSound(SOUND_BONUS);
+  SoundManager::getInstance().playSound(SOUND_BONUS);
 
   game().showArtefactDescription(type);
 
@@ -1077,7 +1077,7 @@ void PlayerEntity::acquireStance(enumItemType type)
   }
 
   spriteItem = new SpriteEntity(
-    ImageManager::getImageManager()->getImage(itemImage),
+    ImageManager::getInstance().getImage(itemImage),
     x, y - 100.0f, ITEM_WIDTH, ITEM_HEIGHT);
   spriteItem->setFrame((int)itemFrame);
   spriteItem->setImagesProLine(10);
@@ -1085,7 +1085,7 @@ void PlayerEntity::acquireStance(enumItemType type)
   spriteItem->setLifetime(ACQUIRE_DELAY);
 
   spriteItemStar = new SpriteEntity(
-    ImageManager::getImageManager()->getImage(IMAGE_STAR),
+    ImageManager::getInstance().getImage(IMAGE_STAR),
     x, y - 100.0f);
   spriteItemStar->setScale(4.0f, 4.0f);
   spriteItemStar->setZ(z-1.0f);
@@ -1124,12 +1124,12 @@ void PlayerEntity::useBossKey()
   playerStatus = playerStatusUnlocking;
   acquireDelay = UNLOCK_DELAY;
   acquiredItem = (enumItemType)(type - FirstEquipItem);
-  SoundManager::getSoundManager()->playSound(SOUND_BONUS);
+  SoundManager::getInstance().playSound(SOUND_BONUS);
   equip[EQUIP_BOSS_KEY] = false;
 
 
   SpriteEntity* spriteItem = new SpriteEntity(
-    ImageManager::getImageManager()->getImage(IMAGE_ITEMS_EQUIP),
+    ImageManager::getInstance().getImage(IMAGE_ITEMS_EQUIP),
     x, y - 100.0f, ITEM_WIDTH, ITEM_HEIGHT);
   spriteItem->setFrame(EQUIP_BOSS_KEY);
   spriteItem->setZ(z);
@@ -1195,7 +1195,7 @@ void PlayerEntity::selectNextShotType()
   else
     specialShotIndex = 0;
 
-  SoundManager::getSoundManager()->playSound(SOUND_SHOT_SELECT);
+  SoundManager::getInstance().playSound(SOUND_SHOT_SELECT);
   computePlayer();
 }
 
@@ -1205,7 +1205,7 @@ void PlayerEntity::initShotType()
   needInitShotType = false;
 
   if (getShotType() == ShotTypeLightning)
-    SoundManager::getSoundManager()->playSound(SOUND_ELECTRIC_CHARGE);
+    SoundManager::getInstance().playSound(SOUND_ELECTRIC_CHARGE);
 }
 
 unsigned int PlayerEntity::getShotLevel()
@@ -1338,7 +1338,7 @@ void PlayerEntity::teleport()
     if (game().getCurrentMap()->isWalkable(xm, ym))
     {
       // enemy or bolt ?
-      EntityManager::EntityList* entityList =EntityManager::getEntityManager()->getList();
+      EntityManager::EntityList* entityList =EntityManager::getInstance().getList();
       EntityManager::EntityList::iterator it;
 
       bool isBad = false;

--- a/src/PnjEntity.cpp
+++ b/src/PnjEntity.cpp
@@ -5,7 +5,7 @@
 
 #include "TextMapper.h"
 
-PnjEntity::PnjEntity(float x, float y, int pnjType) : SpriteEntity (ImageManager::getImageManager()->getImage(IMAGE_PNJ), x, y, 64, 96)
+PnjEntity::PnjEntity(float x, float y, int pnjType) : SpriteEntity (ImageManager::getInstance().getImage(IMAGE_PNJ), x, y, 64, 96)
 {
   this->x = x;
   this->y = y;

--- a/src/RatEntity.cpp
+++ b/src/RatEntity.cpp
@@ -8,7 +8,7 @@
 #include "WitchBlastGame.h"
 
 RatEntity::RatEntity(float x, float y, ratTypeEnum ratType, bool invocated)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_RAT), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_RAT), x, y)
 {
   this->ratType = ratType;
   imagesProLine = 8;
@@ -134,13 +134,13 @@ void RatEntity::collideWithBolt(BoltEntity* boltEntity)
       float xs = (x + boltEntity->getX()) / 2;
       float ys = (y + boltEntity->getY()) / 2;
       boltEntity->collide();
-      SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+      SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
       star->setFading(true);
       star->setZ(y+ 100);
       star->setLifetime(0.7f);
       star->setType(ENTITY_EFFECT);
       star->setSpin(400.0f);
-      SoundManager::getSoundManager()->playSound(SOUND_CLANG_00);
+      SoundManager::getInstance().playSound(SOUND_CLANG_00);
     }
   }
   else EnemyEntity::collideWithBolt(boltEntity);

--- a/src/RockMissileEntity.cpp
+++ b/src/RockMissileEntity.cpp
@@ -7,7 +7,7 @@
 #include "WitchBlastGame.h"
 
 RockMissileEntity::RockMissileEntity(float x, float y, int rockType)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_CYCLOP), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_CYCLOP), x, y)
 {
 
   Vector2D targetPos = game().getPlayerPosition();
@@ -105,12 +105,12 @@ void RockMissileEntity::dying()
 {
   isDying = true;
   game().addKilledEnemy(enemyType);
-  SoundManager::getSoundManager()->playSound(SOUND_ROCK_IMPACT);
+  SoundManager::getInstance().playSound(SOUND_ROCK_IMPACT);
   game().makeShake(0.1f);
 
   for (int i = 0; i < 4; i++)
   {
-    SpriteEntity* blood = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
+    SpriteEntity* blood = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
     blood->setZ(OFFSET_Y - 1);
 
     blood->setFrame(12 + rand()%6);

--- a/src/SlimeEntity.cpp
+++ b/src/SlimeEntity.cpp
@@ -9,7 +9,7 @@
 #include "WitchBlastGame.h"
 
 SlimeEntity::SlimeEntity(float x, float y, slimeTypeEnum slimeType, bool invocated)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_SLIME), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_SLIME), x, y)
 {
   creatureSpeed = 0.0f;
   velocity = Vector2D(0.0f, 0.0f);
@@ -89,7 +89,7 @@ void SlimeEntity::animate(float delay)
         {
           isFirstJumping = false;
           hVelocity = 160.0f;
-          SoundManager::getSoundManager()->playSound(SOUND_SLIME_IMAPCT);
+          SoundManager::getInstance().playSound(SOUND_SLIME_IMAPCT);
           if (slimeType == SlimeTypeBlue || slimeType == SlimeTypeRed)
             fire();
           else if (slimeType == SlimeTypeViolet)
@@ -102,7 +102,7 @@ void SlimeEntity::animate(float delay)
         {
           jumpingDelay = 0.4f + 0.1f * (rand() % 20);
           isJumping = false;
-          SoundManager::getSoundManager()->playSound(SOUND_SLIME_IMAPCT_WEAK);
+          SoundManager::getInstance().playSound(SOUND_SLIME_IMAPCT_WEAK);
         }
       }
     }
@@ -114,7 +114,7 @@ void SlimeEntity::animate(float delay)
     jumpingDelay -= slimeDelay;
     if (jumpingDelay < 0.0f)
     {
-      SoundManager::getSoundManager()->playSound(SOUND_SLIME_JUMP);
+      SoundManager::getInstance().playSound(SOUND_SLIME_JUMP);
       hVelocity = 350.0f + rand() % 300;
       isJumping = true;
       isFirstJumping = true;
@@ -160,7 +160,7 @@ void SlimeEntity::readCollidingEntity(CollidingSpriteEntity* entity)
         {
           float xs = (x + playerEntity->getX()) / 2;
           float ys = (y + playerEntity->getY()) / 2;
-          SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+          SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
           star->setFading(true);
           star->setZ(y+ 100);
           star->setLifetime(0.7f);
@@ -299,7 +299,7 @@ void SlimeEntity::dying()
 {
   isDying = true;
   game().addKilledEnemy(enemyType);
-  SpriteEntity* deadSlime = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_CORPSES), x, y, 64, 64);
+  SpriteEntity* deadSlime = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_CORPSES), x, y, 64, 64);
   deadSlime->setZ(OFFSET_Y);
   deadSlime->setImagesProLine(10);
   switch (slimeType)
@@ -314,7 +314,7 @@ void SlimeEntity::dying()
   for (int i = 0; i < 4; i++) game().generateBlood(x, y, bloodColor);
 
   if (!invocated) drop();
-  SoundManager::getSoundManager()->playSound(SOUND_ENNEMY_DYING);
+  SoundManager::getInstance().playSound(SOUND_ENNEMY_DYING);
 }
 
 void SlimeEntity::prepareDying()
@@ -363,7 +363,7 @@ void SlimeEntity::fire()
       case 3: bolt->setVelocity(Vector2D(0, -SLIME_FIRE_VELOCITY)); break;
     }
   }
-  SoundManager::getSoundManager()->playSound(SOUND_BLAST_FLOWER);
+  SoundManager::getInstance().playSound(SOUND_BLAST_FLOWER);
 }
 
 void SlimeEntity::explode()
@@ -371,14 +371,14 @@ void SlimeEntity::explode()
   ExplosionEntity* expl = new ExplosionEntity(x, y, isPet ? 18 : 12);
 
   game().makeShake(1.0f);
-  SoundManager::getSoundManager()->playSound(SOUND_BOOM_00);
+  SoundManager::getInstance().playSound(SOUND_BOOM_00);
 }
 
 void SlimeEntity::makePet(int direction)
 {
   isPet = true;
   hVelocity = 450.0f;
-  SoundManager::getSoundManager()->playSound(SOUND_SLIME_JUMP);
+  SoundManager::getInstance().playSound(SOUND_SLIME_JUMP);
   isJumping = true;
   isFirstJumping = true;
 

--- a/src/SnakeEntity.cpp
+++ b/src/SnakeEntity.cpp
@@ -8,7 +8,7 @@
 #include "WitchBlastGame.h"
 
 SnakeEntity::SnakeEntity(float x, float y, snakeTypeEnum snakeType, bool invocated)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_SNAKE), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_SNAKE), x, y)
 {
   this->snakeType = snakeType;
   imagesProLine = 10;

--- a/src/SpiderEggEntity.cpp
+++ b/src/SpiderEggEntity.cpp
@@ -9,7 +9,7 @@
 #include "WitchBlastGame.h"
 
 SpiderEggEntity::SpiderEggEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_SPIDER_EGG), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_SPIDER_EGG), x, y)
 {
   imagesProLine = 20;
   type = ENTITY_ENNEMY_INVOCATED;
@@ -70,7 +70,7 @@ void SpiderEggEntity::dyingFromAge()
 
   for (int i = 0; i < 4; i++)
   {
-    SpriteEntity* blood = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
+    SpriteEntity* blood = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
     blood->setZ(OFFSET_Y - 1);
     blood->setFrame(18 + rand()%6);
     blood->setType(ENTITY_BLOOD);
@@ -80,7 +80,7 @@ void SpiderEggEntity::dyingFromAge()
     blood->setScale(bloodScale, bloodScale);
   }
 
-  SoundManager::getSoundManager()->playSound(SOUND_EGG_SMASH_00 + rand() %  2);
+  SoundManager::getInstance().playSound(SOUND_EGG_SMASH_00 + rand() %  2);
 
   isDying = true;
 }
@@ -142,7 +142,7 @@ void SpiderEggEntity::readCollidingEntity(CollidingSpriteEntity* entity)
         {
           float xs = (x + playerEntity->getX()) / 2;
           float ys = (y + playerEntity->getY()) / 2;
-          SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+          SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
           star->setFading(true);
           star->setZ(y+ 100);
           star->setLifetime(0.7f);
@@ -161,9 +161,9 @@ void SpiderEggEntity::readCollidingEntity(CollidingSpriteEntity* entity)
 
         hurt(boltEntity->getDamages(), boltEntity->getBoltType(), boltEntity->getLevel(), boltEntity->isCritical());
         if (bloodColor > BloodNone) game().generateBlood(x, y, bloodColor);
-        SoundManager::getSoundManager()->playSound(SOUND_IMPACT);
+        SoundManager::getInstance().playSound(SOUND_IMPACT);
 
-        SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+        SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
         star->setFading(true);
         star->setZ(y+ 100);
         star->setLifetime(0.7f);

--- a/src/SpiderWebEntity.cpp
+++ b/src/SpiderWebEntity.cpp
@@ -8,7 +8,7 @@
 #include "WitchBlastGame.h"
 
 SpiderWebEntity::SpiderWebEntity(float x, float y)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_SPIDER_WEB), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_SPIDER_WEB), x, y)
 {
   imagesProLine = 20;
   type = ENTITY_ENNEMY_INVOCATED;
@@ -132,9 +132,9 @@ void SpiderWebEntity::readCollidingEntity(CollidingSpriteEntity* entity)
 
         hurt(boltEntity->getDamages(), boltEntity->getBoltType(), boltEntity->getLevel(), boltEntity->isCritical());
         if (bloodColor > BloodNone) game().generateBlood(x, y, bloodColor);
-        SoundManager::getSoundManager()->playSound(SOUND_IMPACT);
+        SoundManager::getInstance().playSound(SOUND_IMPACT);
 
-        SpriteEntity* star = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_STAR_2), xs, ys);
+        SpriteEntity* star = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_STAR_2), xs, ys);
         star->setFading(true);
         star->setZ(y+ 100);
         star->setLifetime(0.7f);

--- a/src/WitchBlastGame.cpp
+++ b/src/WitchBlastGame.cpp
@@ -73,111 +73,111 @@ WitchBlastGame::WitchBlastGame():
   gameptr = this;
 
   // loading resources
-  ImageManager::getImageManager()->addImage("media/player_base.png");
-  ImageManager::getImageManager()->addImage("media/player_equip.png");
-  ImageManager::getImageManager()->addImage("media/player_collar.png");
-  ImageManager::getImageManager()->addImage("media/bolt.png");
-  ImageManager::getImageManager()->addImage("media/tiles.png");
-  ImageManager::getImageManager()->addImage("media/rat.png");
-  ImageManager::getImageManager()->addImage("media/minimap.png");
-  ImageManager::getImageManager()->addImage("media/doors.png");
-  ImageManager::getImageManager()->addImage("media/items.png");
-  ImageManager::getImageManager()->addImage("media/items_equip.png");
-  ImageManager::getImageManager()->addImage("media/chest.png");
-  ImageManager::getImageManager()->addImage("media/bat.png");
-  ImageManager::getImageManager()->addImage("media/evil_flower.png");
-  ImageManager::getImageManager()->addImage("media/slime.png");
-  ImageManager::getImageManager()->addImage("media/imp.png");
-  ImageManager::getImageManager()->addImage("media/spider_egg.png");
-  ImageManager::getImageManager()->addImage("media/spider_web.png");
-  ImageManager::getImageManager()->addImage("media/little_spider.png");
-  ImageManager::getImageManager()->addImage("media/bubble.png");
-  ImageManager::getImageManager()->addImage("media/witch.png");
-  ImageManager::getImageManager()->addImage("media/cauldron.png");
-  ImageManager::getImageManager()->addImage("media/snake.png");
+  ImageManager::getInstance().addImage("media/player_base.png");
+  ImageManager::getInstance().addImage("media/player_equip.png");
+  ImageManager::getInstance().addImage("media/player_collar.png");
+  ImageManager::getInstance().addImage("media/bolt.png");
+  ImageManager::getInstance().addImage("media/tiles.png");
+  ImageManager::getInstance().addImage("media/rat.png");
+  ImageManager::getInstance().addImage("media/minimap.png");
+  ImageManager::getInstance().addImage("media/doors.png");
+  ImageManager::getInstance().addImage("media/items.png");
+  ImageManager::getInstance().addImage("media/items_equip.png");
+  ImageManager::getInstance().addImage("media/chest.png");
+  ImageManager::getInstance().addImage("media/bat.png");
+  ImageManager::getInstance().addImage("media/evil_flower.png");
+  ImageManager::getInstance().addImage("media/slime.png");
+  ImageManager::getInstance().addImage("media/imp.png");
+  ImageManager::getInstance().addImage("media/spider_egg.png");
+  ImageManager::getInstance().addImage("media/spider_web.png");
+  ImageManager::getInstance().addImage("media/little_spider.png");
+  ImageManager::getInstance().addImage("media/bubble.png");
+  ImageManager::getInstance().addImage("media/witch.png");
+  ImageManager::getInstance().addImage("media/cauldron.png");
+  ImageManager::getInstance().addImage("media/snake.png");
 
-  ImageManager::getImageManager()->addImage("media/butcher.png");
-  ImageManager::getImageManager()->addImage("media/giant_slime.png");
-  ImageManager::getImageManager()->addImage("media/king_rat.png");
-  ImageManager::getImageManager()->addImage("media/cyclop.png");
-  ImageManager::getImageManager()->addImage("media/giant_spider.png");
+  ImageManager::getInstance().addImage("media/butcher.png");
+  ImageManager::getInstance().addImage("media/giant_slime.png");
+  ImageManager::getInstance().addImage("media/king_rat.png");
+  ImageManager::getInstance().addImage("media/cyclop.png");
+  ImageManager::getInstance().addImage("media/giant_spider.png");
 
-  ImageManager::getImageManager()->addImage("media/blood.png");
-  ImageManager::getImageManager()->addImage("media/corpses.png");
-  ImageManager::getImageManager()->addImage("media/corpses_big.png");
-  ImageManager::getImageManager()->addImage("media/star.png");
-  ImageManager::getImageManager()->addImage("media/star2.png");
-  ImageManager::getImageManager()->addImage("media/interface.png");
-  ImageManager::getImageManager()->addImage("media/hud_shots.png");
-  ImageManager::getImageManager()->addImage("media/boom64.png");
-  ImageManager::getImageManager()->addImage("media/keys_qwer.png");
-  ImageManager::getImageManager()->addImage("media/keys_azer.png");
+  ImageManager::getInstance().addImage("media/blood.png");
+  ImageManager::getInstance().addImage("media/corpses.png");
+  ImageManager::getInstance().addImage("media/corpses_big.png");
+  ImageManager::getInstance().addImage("media/star.png");
+  ImageManager::getInstance().addImage("media/star2.png");
+  ImageManager::getInstance().addImage("media/interface.png");
+  ImageManager::getInstance().addImage("media/hud_shots.png");
+  ImageManager::getInstance().addImage("media/boom64.png");
+  ImageManager::getInstance().addImage("media/keys_qwer.png");
+  ImageManager::getInstance().addImage("media/keys_azer.png");
 
-  ImageManager::getImageManager()->addImage("media/pnj.png");
-  ImageManager::getImageManager()->addImage("media/fairy.png");
+  ImageManager::getInstance().addImage("media/pnj.png");
+  ImageManager::getInstance().addImage("media/fairy.png");
 
-  SoundManager::getSoundManager()->addSound("media/sound/blast00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/blast01.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/door_closing.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/door_opening.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/chest_opening.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/impact.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/bonus.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/drink.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/eat.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/player_hit.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/player_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/ennemy_dying.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/coin.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/pay.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/wall_impact.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/big_wall_impact.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/king_rat_cry_1.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/king_rat_cry_2.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/king_rat_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/slime_jump.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/slime_impact.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/slime_impact_weak.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/slime_smash.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/ice_charge.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/electric.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/select.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/heart.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/rat_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/bat_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/imp_hurt.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/imp_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/rock_impact.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/throw.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/cyclop00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/cyclop_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/butcher_00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/butcher_01.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/butcher_hurt.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/butcher_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/vib.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/boom_00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/clang_00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/bubble_00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/bubble_01.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/trap.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/egg_smash_00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/egg_smash_01.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/spider_walking.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/spider_web.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/spider_hurt.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/spider_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/little_spider_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/witch_00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/witch_01.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/witch_die_00.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/witch_die_01.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/witch_02.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/invoke.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/cauldron.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/cauldron_die.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/critical.ogg");
-  SoundManager::getSoundManager()->addSound("media/sound/gong.ogg");
+  SoundManager::getInstance().addSound("media/sound/blast00.ogg");
+  SoundManager::getInstance().addSound("media/sound/blast01.ogg");
+  SoundManager::getInstance().addSound("media/sound/door_closing.ogg");
+  SoundManager::getInstance().addSound("media/sound/door_opening.ogg");
+  SoundManager::getInstance().addSound("media/sound/chest_opening.ogg");
+  SoundManager::getInstance().addSound("media/sound/impact.ogg");
+  SoundManager::getInstance().addSound("media/sound/bonus.ogg");
+  SoundManager::getInstance().addSound("media/sound/drink.ogg");
+  SoundManager::getInstance().addSound("media/sound/eat.ogg");
+  SoundManager::getInstance().addSound("media/sound/player_hit.ogg");
+  SoundManager::getInstance().addSound("media/sound/player_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/ennemy_dying.ogg");
+  SoundManager::getInstance().addSound("media/sound/coin.ogg");
+  SoundManager::getInstance().addSound("media/sound/pay.ogg");
+  SoundManager::getInstance().addSound("media/sound/wall_impact.ogg");
+  SoundManager::getInstance().addSound("media/sound/big_wall_impact.ogg");
+  SoundManager::getInstance().addSound("media/sound/king_rat_cry_1.ogg");
+  SoundManager::getInstance().addSound("media/sound/king_rat_cry_2.ogg");
+  SoundManager::getInstance().addSound("media/sound/king_rat_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/slime_jump.ogg");
+  SoundManager::getInstance().addSound("media/sound/slime_impact.ogg");
+  SoundManager::getInstance().addSound("media/sound/slime_impact_weak.ogg");
+  SoundManager::getInstance().addSound("media/sound/slime_smash.ogg");
+  SoundManager::getInstance().addSound("media/sound/ice_charge.ogg");
+  SoundManager::getInstance().addSound("media/sound/electric.ogg");
+  SoundManager::getInstance().addSound("media/sound/select.ogg");
+  SoundManager::getInstance().addSound("media/sound/heart.ogg");
+  SoundManager::getInstance().addSound("media/sound/rat_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/bat_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/imp_hurt.ogg");
+  SoundManager::getInstance().addSound("media/sound/imp_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/rock_impact.ogg");
+  SoundManager::getInstance().addSound("media/sound/throw.ogg");
+  SoundManager::getInstance().addSound("media/sound/cyclop00.ogg");
+  SoundManager::getInstance().addSound("media/sound/cyclop_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/butcher_00.ogg");
+  SoundManager::getInstance().addSound("media/sound/butcher_01.ogg");
+  SoundManager::getInstance().addSound("media/sound/butcher_hurt.ogg");
+  SoundManager::getInstance().addSound("media/sound/butcher_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/vib.ogg");
+  SoundManager::getInstance().addSound("media/sound/boom_00.ogg");
+  SoundManager::getInstance().addSound("media/sound/clang_00.ogg");
+  SoundManager::getInstance().addSound("media/sound/bubble_00.ogg");
+  SoundManager::getInstance().addSound("media/sound/bubble_01.ogg");
+  SoundManager::getInstance().addSound("media/sound/trap.ogg");
+  SoundManager::getInstance().addSound("media/sound/egg_smash_00.ogg");
+  SoundManager::getInstance().addSound("media/sound/egg_smash_01.ogg");
+  SoundManager::getInstance().addSound("media/sound/spider_walking.ogg");
+  SoundManager::getInstance().addSound("media/sound/spider_web.ogg");
+  SoundManager::getInstance().addSound("media/sound/spider_hurt.ogg");
+  SoundManager::getInstance().addSound("media/sound/spider_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/little_spider_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/witch_00.ogg");
+  SoundManager::getInstance().addSound("media/sound/witch_01.ogg");
+  SoundManager::getInstance().addSound("media/sound/witch_die_00.ogg");
+  SoundManager::getInstance().addSound("media/sound/witch_die_01.ogg");
+  SoundManager::getInstance().addSound("media/sound/witch_02.ogg");
+  SoundManager::getInstance().addSound("media/sound/invoke.ogg");
+  SoundManager::getInstance().addSound("media/sound/cauldron.ogg");
+  SoundManager::getInstance().addSound("media/sound/cauldron_die.ogg");
+  SoundManager::getInstance().addSound("media/sound/critical.ogg");
+  SoundManager::getInstance().addSound("media/sound/gong.ogg");
 
   if (font.loadFromFile("media/DejaVuSans-Bold.ttf"))
   {
@@ -192,7 +192,7 @@ WitchBlastGame::WitchBlastGame():
   isPausing = false;
   showLogical = false;
 
-  shotsSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_HUD_SHOTS));
+  shotsSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_HUD_SHOTS));
 
   configureFromFile();
   srand(time(NULL));
@@ -203,7 +203,7 @@ WitchBlastGame::WitchBlastGame():
 WitchBlastGame::~WitchBlastGame()
 {
   // cleaning all entities
-  EntityManager::getEntityManager()->clean();
+  EntityManager::getInstance().clean();
 
   // cleaning data
   if (miniMap != NULL) delete (miniMap);
@@ -241,14 +241,14 @@ void WitchBlastGame::onUpdate()
   if (!isPausing)
   {
     checkFallingEntities();
-    EntityManager::getEntityManager()->animate(deltaTime);
+    EntityManager::getInstance().animate(deltaTime);
     if (sf::Keyboard::isKeyPressed(input[KeyTimeControl]))
     {
-      EntityManager::getEntityManager()->animate(deltaTime);
-      SoundManager::getSoundManager()->playSound(SOUND_VIB);
+      EntityManager::getInstance().animate(deltaTime);
+      SoundManager::getInstance().playSound(SOUND_VIB);
     }
     else
-      SoundManager::getSoundManager()->stopSound(SOUND_VIB);
+      SoundManager::getInstance().stopSound(SOUND_VIB);
 
     if (xGameState != xGameStateNone)
     {
@@ -288,7 +288,7 @@ void WitchBlastGame::startNewGame(bool fromSaveFile)
   level = 1;
 
   // cleaning all entities
-  EntityManager::getEntityManager()->clean();
+  EntityManager::getInstance().clean();
 
   // cleaning data
   if (miniMap != NULL) delete (miniMap);
@@ -297,24 +297,24 @@ void WitchBlastGame::startNewGame(bool fromSaveFile)
   currentFloor = NULL;
 
   // current map (tiles)
-  currentTileMap = new TileMapEntity(ImageManager::getImageManager()->getImage(IMAGE_TILES), currentMap, 64, 64, 10);
+  currentTileMap = new TileMapEntity(ImageManager::getInstance().getImage(IMAGE_TILES), currentMap, 64, 64, 10);
   currentTileMap->setX(OFFSET_X);
   currentTileMap->setY(OFFSET_Y);
 
   // the interface
-  SpriteEntity* interface = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_INTERFACE));
+  SpriteEntity* interface = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_INTERFACE));
   interface->setZ(10000.0f);
   interface->removeCenter();
   interface->setType(0);
 
   // key symbol on the interface
-  keySprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_ITEMS_EQUIP));
+  keySprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_ITEMS_EQUIP));
   keySprite.setTextureRect(sf::IntRect(ITEM_WIDTH * EQUIP_BOSS_KEY, 0,  ITEM_WIDTH, ITEM_HEIGHT));
   keySprite.setPosition(326, 616);
 
   miniMap = new GameMap(FLOOR_WIDTH, FLOOR_HEIGHT);
   // minimap on the interface
-  TileMapEntity* miniMapEntity = new TileMapEntity(ImageManager::getImageManager()->getImage(IMAGE_MINIMAP), miniMap, 15, 11, 12);
+  TileMapEntity* miniMapEntity = new TileMapEntity(ImageManager::getInstance().getImage(IMAGE_MINIMAP), miniMap, 15, 11, 12);
   miniMapEntity->setTileBox(16, 12);
   miniMapEntity->setX(407);
   miniMapEntity->setY(614);
@@ -566,7 +566,7 @@ void WitchBlastGame::updateRunningGame()
 
 void WitchBlastGame::renderRunningGame()
 {
-  EntityManager::getEntityManager()->sortByZ();
+  EntityManager::getInstance().sortByZ();
   if (xGameState == xGameStateShake)
   {
     sf::View view = app->getDefaultView();
@@ -574,15 +574,15 @@ void WitchBlastGame::renderRunningGame()
     view.move(-4 + rand() % 9, -4 + rand() % 9);
     app->setView(view);
 
-    EntityManager::getEntityManager()->renderUnder(app, 5000);
+    EntityManager::getInstance().renderUnder(app, 5000);
 
     app->setView(viewSave);
-    EntityManager::getEntityManager()->renderAfter(app, 5000);
+    EntityManager::getInstance().renderAfter(app, 5000);
   }
   else
   {
     // render the game objects
-    EntityManager::getEntityManager()->render(app);
+    EntityManager::getInstance().render(app);
   }
 
   myText.setColor(sf::Color(255, 255, 255, 255));
@@ -639,7 +639,7 @@ void WitchBlastGame::renderRunningGame()
       write(tools::getLabel(spellLabel[player->getActiveSpell().spell]), 14, 95, 663, ALIGN_LEFT, sf::Color::White, app, 0, 0);
       // TODO
       sf::Sprite itemSprite;
-      itemSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_ITEMS_EQUIP));
+      itemSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_ITEMS_EQUIP));
       itemSprite.setPosition(10, 620);
       int frame = player->getActiveSpell().frame;
       itemSprite.setTextureRect(sf::IntRect((frame % 10) * 32, (frame / 10) * 32, 32, 32));
@@ -764,7 +764,7 @@ void WitchBlastGame::renderDeathScreen()
       if (i != EQUIP_BOSS_KEY && player->isEquiped(i))
       {
         sf::Sprite itemSprite;
-        itemSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_ITEMS_EQUIP));
+        itemSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_ITEMS_EQUIP));
         itemSprite.setPosition(xItems + 120 + n * 32, yItems - 5);
         itemSprite.setTextureRect(sf::IntRect((i % 10) * 32, (i / 10) * 32, 32, 32));
         app->draw(itemSprite);
@@ -785,95 +785,95 @@ void WitchBlastGame::renderDeathScreen()
         switch (i)
         {
         case EnemyTypeBat:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_BAT));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_BAT));
           monsterSprite.setTextureRect(sf::IntRect(64, 0, 64, 64));
           dy = -1;
           break;
 
         case EnemyTypeRat:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_RAT));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_RAT));
           monsterSprite.setTextureRect(sf::IntRect(0, 12, 64, 52));
           break;
 
         case EnemyTypeRatBlack:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_RAT));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_RAT));
           monsterSprite.setTextureRect(sf::IntRect(0, 140, 64, 52));
           break;
 
         case EnemyTypeRatHelmet:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_RAT));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_RAT));
           monsterSprite.setTextureRect(sf::IntRect(0, 204, 64, 52));
           break;
 
         case EnemyTypeRatBlackHelmet:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_RAT));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_RAT));
           monsterSprite.setTextureRect(sf::IntRect(0, 268, 64, 52));
           break;
 
         case EnemyTypeEvilFlower:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_FLOWER));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_FLOWER));
           monsterSprite.setTextureRect(sf::IntRect(0, 0, 64, 64));
           break;
 
         case EnemyTypeSnake:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_SNAKE));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_SNAKE));
           monsterSprite.setTextureRect(sf::IntRect(0, 10, 64, 54));
           dy = 2;
           break;
 
         case EnemyTypeSlime:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_SLIME));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_SLIME));
           monsterSprite.setTextureRect(sf::IntRect(0, 10, 64, 44));
           break;
 
         case EnemyTypeSlimeRed:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_SLIME));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_SLIME));
           monsterSprite.setTextureRect(sf::IntRect(0, 74, 64, 54));
           break;
 
         case EnemyTypeSlimeBlue:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_SLIME));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_SLIME));
           monsterSprite.setTextureRect(sf::IntRect(0, 138, 64, 54));
           break;
 
         case EnemyTypeSlimeViolet:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_SLIME));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_SLIME));
           monsterSprite.setTextureRect(sf::IntRect(0, 202, 64, 54));
           break;
 
         case EnemyTypeImpBlue:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_IMP));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_IMP));
           monsterSprite.setTextureRect(sf::IntRect(0, 64, 64, 64));
           dy = -2;
           break;
 
         case EnemyTypeImpRed:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_IMP));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_IMP));
           monsterSprite.setTextureRect(sf::IntRect(0, 0, 64, 64));
           dy = -2;
           break;
 
         case EnemyTypeWitch:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_WITCH));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_WITCH));
           monsterSprite.setTextureRect(sf::IntRect(0, 18, 64, 50));
           dy = -1;
           break;
 
         case EnemyTypeWitchRed:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_WITCH));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_WITCH));
           monsterSprite.setTextureRect(sf::IntRect(0, 114, 64, 50));
           dy = -1;
           break;
 
         case EnemyTypeCauldron:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_CAULDRON));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_CAULDRON));
           monsterSprite.setTextureRect(sf::IntRect(0, 0, 64, 64));
           monsterSprite.setScale(0.65f, 0.65);
           dy = -1;
           break;
 
         case EnemyTypeBubble:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_BUBBLE));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_BUBBLE));
           monsterSprite.setTextureRect(sf::IntRect(0, 0, 128, 128));
           monsterSprite.setScale(0.25f, 0.25f);
           dy = -1;
@@ -897,31 +897,31 @@ void WitchBlastGame::renderDeathScreen()
         switch (i)
         {
         case EnemyTypeButcher:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_BUTCHER));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_BUTCHER));
           monsterSprite.setTextureRect(sf::IntRect(32, 0, 64, 128));
           dy = -5;
           break;
 
         case EnemyTypeSlimeBoss:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_GIANT_SLIME));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_GIANT_SLIME));
           monsterSprite.setTextureRect(sf::IntRect(7, 0, 120, 128));
           dy = -1;
           break;
 
         case EnemyTypeCyclops:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_CYCLOP));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_CYCLOP));
           monsterSprite.setTextureRect(sf::IntRect(0, 0, 128, 192));
           monsterSprite.setScale(0.6f, 0.6f);
           dy = -21;
           break;
 
         case EnemyTypeRatKing:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_KING_RAT));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_KING_RAT));
           monsterSprite.setTextureRect(sf::IntRect(12, 0, 128, 116));
           break;
 
         case EnemyTypeSpiderGiant:
-          monsterSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_GIANT_SPIDER));
+          monsterSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_GIANT_SPIDER));
           monsterSprite.setTextureRect(sf::IntRect(0, 0, 128, 128));
           dy = 2;
           break;
@@ -944,7 +944,7 @@ void WitchBlastGame::renderDeathScreen()
 
 void WitchBlastGame::switchToMenu()
 {
-  EntityManager::getEntityManager()->clean();
+  EntityManager::getInstance().clean();
 
   if (menuMap != NULL) delete menuMap;
   menuMap = new GameMap(MENU_MAP_WIDTH, MENU_MAP_HEIGHT);
@@ -966,7 +966,7 @@ void WitchBlastGame::switchToMenu()
           menuMap->setTile(i, j, menuMap->getTile(i, j) + 10);
       }
     }
-  menuTileMap = new TileMapEntity(ImageManager::getImageManager()->getImage(IMAGE_TILES), menuMap, 64, 64, 10);
+  menuTileMap = new TileMapEntity(ImageManager::getInstance().getImage(IMAGE_TILES), menuMap, 64, 64, 10);
   menuTileMap->setX(-30.0f);
   menuTileMap->setY(-20.0f);
 
@@ -992,7 +992,7 @@ void WitchBlastGame::updateMenu()
   else if (menuState == MenuStateFirst)
     menu = &menuFirst;
 
-  EntityManager::getEntityManager()->animate(deltaTime);
+  EntityManager::getInstance().animate(deltaTime);
   if (menu != NULL) menu->age += deltaTime;
   float mapY = menuTileMap->getY();
   mapY -= 30.0f * deltaTime;
@@ -1065,7 +1065,7 @@ void WitchBlastGame::updateMenu()
       {
         menu->index++;
         if (menu->index == menu->items.size()) menu->index = 0;
-        SoundManager::getSoundManager()->playSound(SOUND_SHOT_SELECT);
+        SoundManager::getInstance().playSound(SOUND_SHOT_SELECT);
       }
 
       else if (event.key.code == input[KeyUp] || event.key.code == sf::Keyboard::Up)
@@ -1073,13 +1073,13 @@ void WitchBlastGame::updateMenu()
         if (menu->index == 0) menu->index = menu->items.size() - 1;
         else menu->index--;
 
-        SoundManager::getSoundManager()->playSound(SOUND_SHOT_SELECT);
+        SoundManager::getInstance().playSound(SOUND_SHOT_SELECT);
       }
       else if (event.key.code == input[KeyRight] || event.key.code == sf::Keyboard::Right)
       {
         if (menu->items[menu->index].id == MenuLanguage)
         {
-          SoundManager::getSoundManager()->playSound(SOUND_SHOT_SELECT);
+          SoundManager::getInstance().playSound(SOUND_SHOT_SELECT);
           parameters.language++;
           if (parameters.language >= NB_LANGUAGES) parameters.language = 0;
           if (menuState == MenuStateConfig) saveConfigurationToFile();
@@ -1091,7 +1091,7 @@ void WitchBlastGame::updateMenu()
       {
         if (menu->items[menu->index].id == MenuLanguage)
         {
-          SoundManager::getSoundManager()->playSound(SOUND_SHOT_SELECT);
+          SoundManager::getInstance().playSound(SOUND_SHOT_SELECT);
           parameters.language--;
           if (parameters.language < 0) parameters.language = NB_LANGUAGES - 1;
           if (menuState == MenuStateConfig) saveConfigurationToFile();
@@ -1139,7 +1139,7 @@ void WitchBlastGame::updateMenu()
 void WitchBlastGame::renderMenu()
 {
   // rendering tiles
-  EntityManager::getEntityManager()->render(app);
+  EntityManager::getInstance().render(app);
 
   // title
   write("Witch Blast", 70, 485, 120, ALIGN_CENTER, sf::Color(255, 255, 255, 255), app, 3, 3);
@@ -1215,9 +1215,9 @@ void WitchBlastGame::renderMenu()
       int yKeys = 380;
       sf::Sprite keysSprite;
       if (parameters.language == 1) // french
-        keysSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_KEYS_AZER));
+        keysSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_KEYS_AZER));
       else
-        keysSprite.setTexture(*ImageManager::getImageManager()->getImage(IMAGE_KEYS_QWER));
+        keysSprite.setTexture(*ImageManager::getInstance().getImage(IMAGE_KEYS_QWER));
       keysSprite.setPosition(xKeys, yKeys);
       app->draw(keysSprite);
 
@@ -1295,7 +1295,7 @@ void WitchBlastGame::openDoors()
     for(j = 0; j < MAP_WIDTH; j++)
       if (currentMap->getTile(i, j) == MAP_DOOR) currentMap->setTile(i, j, MAP_DOOR_OPEN);
   roomClosed = false;
-  SoundManager::getSoundManager()->playSound(SOUND_DOOR_OPENING);
+  SoundManager::getInstance().playSound(SOUND_DOOR_OPENING);
 
   if (currentMap->hasNeighbourUp() == 2 && !bossRoomOpened)
     currentMap->setTile(MAP_WIDTH/2, 0, MAP_DOOR);
@@ -1322,7 +1322,7 @@ int WitchBlastGame::getEnnemyCount()
 {
   int n=0;
 
-  EntityManager::EntityList* entityList =EntityManager::getEntityManager()->getList();
+  EntityManager::EntityList* entityList =EntityManager::getInstance().getList();
   EntityManager::EntityList::iterator it;
 
   for (it = entityList->begin (); it != entityList->end ();)
@@ -1341,7 +1341,7 @@ Vector2D WitchBlastGame::getNearestEnnemy(float x, float y)
   Vector2D target(-100.0f, -100.0f);
   float distanceMin = -1.0f;
 
-  EntityManager::EntityList* entityList =EntityManager::getEntityManager()->getList();
+  EntityManager::EntityList* entityList =EntityManager::getInstance().getList();
   EntityManager::EntityList::iterator it;
 
   for (it = entityList->begin (); it != entityList->end ();)
@@ -1410,7 +1410,7 @@ void WitchBlastGame::checkDoor(int doorId, roomTypeEnum roomCurrent, roomTypeEnu
 void WitchBlastGame::refreshMap()
 {
   // clean the sprites from old map
-  EntityManager::getEntityManager()->partialClean(10);
+  EntityManager::getInstance().partialClean(10);
 
   // if new map, it has to be randomized
   bool generateMap = !(currentFloor->getMap(floorX, floorY)->isVisited());
@@ -1482,7 +1482,7 @@ void WitchBlastGame::checkEntering()
   if (!currentMap->isCleared())
   {
     player->setEntering();
-    SoundManager::getSoundManager()->playSound(SOUND_DOOR_CLOSING);
+    SoundManager::getInstance().playSound(SOUND_DOOR_CLOSING);
     for (int i=0; i<4; i++)
       doorEntity[i]->closeDoor();
   }
@@ -1490,7 +1490,7 @@ void WitchBlastGame::checkEntering()
 
 void WitchBlastGame::saveMapItems()
 {
-  EntityManager::EntityList* entityList = EntityManager::getEntityManager()->getList();
+  EntityManager::EntityList* entityList = EntityManager::getInstance().getList();
   EntityManager::EntityList::iterator it;
 
   for (it = entityList->begin (); it != entityList->end ();)
@@ -1632,7 +1632,7 @@ void WitchBlastGame::generateBlood(float x, float y, BaseCreatureEntity::enumBlo
 
   for (int i=0; i < nbIt; i++)
   {
-    SpriteEntity* blood = new SpriteEntity(ImageManager::getImageManager()->getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
+    SpriteEntity* blood = new SpriteEntity(ImageManager::getInstance().getImage(IMAGE_BLOOD), x, y, 16, 16, 6);
     blood->setZ(OFFSET_Y - 1);
     int b0 = 0;
     if (bloodColor == BaseCreatureEntity::BloodGreen) b0 += 6;
@@ -2011,7 +2011,7 @@ void WitchBlastGame::generateChallengeBonus(float x, float y)
   }
 
   // sound
-    SoundManager::getSoundManager()->playSound(SOUND_GONG);
+    SoundManager::getInstance().playSound(SOUND_GONG);
 
   // text
   float x0 = OFFSET_X + MAP_WIDTH * 0.5f * TILE_WIDTH;
@@ -2037,7 +2037,7 @@ void WitchBlastGame::verifyDoorUnlocking()
     {
       doorEntity[0]->openDoor();
       currentMap->setTile(MAP_WIDTH / 2, 0, 0);
-      SoundManager::getSoundManager()->playSound(SOUND_DOOR_OPENING);
+      SoundManager::getInstance().playSound(SOUND_DOOR_OPENING);
       player->useBossKey();
       bossRoomOpened = true;
     }
@@ -2045,7 +2045,7 @@ void WitchBlastGame::verifyDoorUnlocking()
     {
       doorEntity[2]->openDoor();
       currentMap->setTile(MAP_WIDTH / 2, MAP_HEIGHT - 1, 0);
-      SoundManager::getSoundManager()->playSound(SOUND_DOOR_OPENING);
+      SoundManager::getInstance().playSound(SOUND_DOOR_OPENING);
       player->useBossKey();
       bossRoomOpened = true;
     }
@@ -2054,7 +2054,7 @@ void WitchBlastGame::verifyDoorUnlocking()
 
       doorEntity[1]->openDoor();
       currentMap->setTile(0, MAP_HEIGHT / 2, 0);
-      SoundManager::getSoundManager()->playSound(SOUND_DOOR_OPENING);
+      SoundManager::getInstance().playSound(SOUND_DOOR_OPENING);
       player->useBossKey();
       bossRoomOpened = true;
     }
@@ -2062,7 +2062,7 @@ void WitchBlastGame::verifyDoorUnlocking()
     {
       doorEntity[3]->openDoor();
       currentMap->setTile(MAP_WIDTH - 1, MAP_HEIGHT / 2, 0);
-      SoundManager::getSoundManager()->playSound(SOUND_DOOR_OPENING);
+      SoundManager::getInstance().playSound(SOUND_DOOR_OPENING);
       player->useBossKey();
       bossRoomOpened = true;
     }
@@ -2589,7 +2589,7 @@ void WitchBlastGame::buildMenu(bool rebuild)
 
 void WitchBlastGame::checkFallingEntities()
 {
-  EntityManager::EntityList* entityList =EntityManager::getEntityManager()->getList();
+  EntityManager::EntityList* entityList =EntityManager::getInstance().getList();
   EntityManager::EntityList::iterator it;
 
   for (it = entityList->begin (); it != entityList->end ();)

--- a/src/WitchEntity.cpp
+++ b/src/WitchEntity.cpp
@@ -11,7 +11,7 @@
 #include "WitchBlastGame.h"
 
 WitchEntity::WitchEntity(float x, float y, witchTypeEnum witchType)
-  : EnemyEntity (ImageManager::getImageManager()->getImage(IMAGE_WITCH), x, y)
+  : EnemyEntity (ImageManager::getInstance().getImage(IMAGE_WITCH), x, y)
 {
   this->witchType = witchType;
   imagesProLine = 8;
@@ -66,7 +66,7 @@ void WitchEntity::animate(float delay)
         state = 1;
         velocity = Vector2D(0.0f, 0.0f);
         timer = 0.6f;
-        SoundManager::getSoundManager()->playSound(SOUND_WITCH_00 + rand() % 3);
+        SoundManager::getInstance().playSound(SOUND_WITCH_00 + rand() % 3);
         if (rand() % 7 == 0)
         {
           // invoke
@@ -76,7 +76,7 @@ void WitchEntity::animate(float delay)
           y0 = y0 * TILE_HEIGHT + TILE_HEIGHT / 2;
           if (witchType == WitchTypeNormal) new RatEntity(x0, y0, RatEntity::RatTypeNormal, true);
           else new BatEntity(x0, y0, true);
-          SoundManager::getSoundManager()->playSound(SOUND_INVOKE);
+          SoundManager::getInstance().playSound(SOUND_INVOKE);
 
           for(int i=0; i < 6; i++)
           {
@@ -180,7 +180,7 @@ void WitchEntity::fire()
 {
   if (witchType == WitchTypeNormal)
   {
-    SoundManager::getSoundManager()->playSound(SOUND_BLAST_FLOWER);
+    SoundManager::getInstance().playSound(SOUND_BLAST_FLOWER);
     EnnemyBoltEntity* bolt = new EnnemyBoltEntity
           (x, y + 10, ShotTypeStandard, 0);
     bolt->setMap(map, TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);
@@ -191,7 +191,7 @@ void WitchEntity::fire()
   }
   else
   {
-    SoundManager::getSoundManager()->playSound(SOUND_BLAST_FLOWER);
+    SoundManager::getInstance().playSound(SOUND_BLAST_FLOWER);
     EnnemyBoltEntity* bolt = new EnnemyBoltEntity
           (x, y + 10, ShotTypeBomb, 0);
     bolt->setMap(map, TILE_WIDTH, TILE_HEIGHT, OFFSET_X, OFFSET_Y);

--- a/src/sfml_game/CollidingSpriteEntity.cpp
+++ b/src/sfml_game/CollidingSpriteEntity.cpp
@@ -286,7 +286,7 @@ bool CollidingSpriteEntity::collideWithEntity(CollidingSpriteEntity* entity)
 
 void CollidingSpriteEntity::testSpriteCollisions()
 {
-  EntityManager::EntityList* entityList = EntityManager::getEntityManager()->getList();
+  EntityManager::EntityList* entityList = EntityManager::getInstance().getList();
 
   EntityManager::EntityList::iterator it;
   EntityManager::EntityList::iterator oldit = entityList->begin ();

--- a/src/sfml_game/EntityManager.cpp
+++ b/src/sfml_game/EntityManager.cpp
@@ -26,11 +26,11 @@ EntityManager::EntityManager()
 	mItems = 0;
 }
 
- EntityManager* EntityManager::getEntityManager()
- {
-   static EntityManager singleton;
-   return &singleton;
- }
+EntityManager& EntityManager::getInstance()
+{
+    static EntityManager singleton;
+    return singleton;
+}
 
 
 void EntityManager::add(GameEntity* g)

--- a/src/sfml_game/EntityManager.h
+++ b/src/sfml_game/EntityManager.h
@@ -25,7 +25,7 @@ class EntityManager
 {
 
 public:
-  static EntityManager* getEntityManager();
+  static EntityManager& getInstance();
 
   void initIterator();
 	void add(GameEntity* g);

--- a/src/sfml_game/Game.cpp
+++ b/src/sfml_game/Game.cpp
@@ -80,7 +80,7 @@ void Game::onRender()
     app->clear(sf::Color(32, 32, 32));
 
     // render the game objects
-    EntityManager::getEntityManager()->render(app);
+    EntityManager::getInstance().render(app);
 
     app->display();
 }
@@ -89,6 +89,6 @@ void Game::onUpdate()
 {
   float delta = getAbsolutTime() - lastTime;
   lastTime = getAbsolutTime();
-  EntityManager::getEntityManager()->animate(delta);
+  EntityManager::getInstance().animate(delta);
 }
 

--- a/src/sfml_game/GameEntity.cpp
+++ b/src/sfml_game/GameEntity.cpp
@@ -48,7 +48,7 @@ GameEntity::GameEntity(float m_x, float m_y)
 	angle = 0.0f;
 	spin = 0.0f;
 
-	EntityManager::getEntityManager()->add(this);
+	EntityManager::getInstance().add(this);
 }
 
 GameEntity::~GameEntity()

--- a/src/sfml_game/ImageManager.cpp
+++ b/src/sfml_game/ImageManager.cpp
@@ -32,11 +32,11 @@ ImageManager::~ImageManager()
     std::cout << "OK" << std::endl;
 }
 
- ImageManager* ImageManager::getImageManager()
- {
-   static ImageManager singleton;
-   return &singleton;
- }
+ImageManager& ImageManager::getInstance()
+{
+    static ImageManager singleton;
+    return singleton;
+}
 
 void ImageManager::addImage(const char* fileName)
 {

--- a/src/sfml_game/ImageManager.h
+++ b/src/sfml_game/ImageManager.h
@@ -22,7 +22,7 @@
 class ImageManager
 {
 public:
-    static ImageManager* getImageManager();
+    static ImageManager& getInstance();
     void addImage(const char *fileName);
     bool reloadImage(int n, const char* fileName);
     sf::Texture* getImage(int n);

--- a/src/sfml_game/SoundManager.cpp
+++ b/src/sfml_game/SoundManager.cpp
@@ -36,11 +36,11 @@ SoundManager::~SoundManager()
     std::cout << "OK" << std::endl;
 }
 
- SoundManager* SoundManager::getSoundManager()
- {
-   static SoundManager singleton;
-   return &singleton;
- }
+SoundManager& SoundManager::getInstance()
+{
+    static SoundManager singleton;
+    return singleton;
+}
 
 void SoundManager::addSound(const char* fileName)
 {

--- a/src/sfml_game/SoundManager.h
+++ b/src/sfml_game/SoundManager.h
@@ -22,7 +22,7 @@
 class SoundManager
 {
 public:
-    static SoundManager* getSoundManager();
+    static SoundManager& getInstance();
     void addSound(const char *fileName);
     void playSound(int n);
     void stopSound(int n);


### PR DESCRIPTION
FooManager::getFooManager() contains redundant information, and is
longer than getInstance().

Return references instead of pointers, as they are more appropriate
for returning a reference to the manager.
