### PR TITLE
Remove 'using namespace std' from header files

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -32,9 +32,9 @@ bool Config::configFileExists()
   return configFileExistsFlag;
 }
 
-void Config::loadFromFile(string file)
+void Config::loadFromFile(std::string file)
 {
-  ifstream f(file.c_str());
+  std::ifstream f(file.c_str());
   if (!f.is_open())
   {
     configFileExistsFlag = false;
@@ -42,11 +42,11 @@ void Config::loadFromFile(string file)
   else
   {
     configFileExistsFlag = true;
-    string key;
+    std::string key;
 
     while (f >> key)
     {
-      string data;
+      std::string data;
       if (f >> data)
       {
         configMap[key] = data;
@@ -59,11 +59,11 @@ void Config::loadFromFile(string file)
 
 void Config::saveToFile(std::string fileName, std::map<std::string, std::string> newMap)
 {
-  std::ofstream file(fileName.c_str(), ios::out | ios::trunc);
+  std::ofstream file(fileName.c_str(), std::ios::out | std::ios::trunc);
   if (file)
   {
     configFileExistsFlag = true;
-    map<std::string, std::string>::iterator it;
+    std::map<std::string, std::string>::iterator it;
 
     for(it = newMap.begin(); it != newMap.end(); it++)
     {

--- a/src/Config.h
+++ b/src/Config.h
@@ -20,17 +20,15 @@
 #include <map>
 #include "Constants.h"
 
-using namespace std;
-
 class Config
 {
 public:
   Config();
-  void loadFromFile(string file);
+  void loadFromFile(std::string file);
   void saveToFile(std::string file, std::map<std::string, std::string> newMap);
   void displayMap();
 
-  int findInt(string key);
+  int findInt(std::string key);
   bool configFileExists();
 
 private:

--- a/src/WitchBlastGame.cpp
+++ b/src/WitchBlastGame.cpp
@@ -2112,7 +2112,7 @@ void WitchBlastGame::saveGame()
 {
   if (player->getPlayerStatus() == PlayerEntity::playerStatusAcquire)
     player->acquireItemAfterStance();
-  ofstream file(SAVE_FILE.c_str(), ios::out | ios::trunc);
+  std::ofstream file(SAVE_FILE.c_str(), std::ios::out | std::ios::trunc);
 
   int i, j, k, l;
 
@@ -2132,14 +2132,14 @@ void WitchBlastGame::saveGame()
     if (now->tm_mday < 9) file << "0";
 
     file <<  now->tm_mday
-         << endl;
+         << std::endl;
 
     if (now->tm_hour <= 9) file << "0";
 
     file << (now->tm_hour) << ':';
 
     if (now->tm_min <= 9) file << "0";
-    file << (now->tm_min) << endl;
+    file << (now->tm_min) << std::endl;
 
     // floor
     file << level << std::endl;
@@ -2241,13 +2241,13 @@ void WitchBlastGame::saveGame()
   }
   else
   {
-    cerr << "[ERROR] Saving the game..." << endl;
+    std::cerr << "[ERROR] Saving the game..." << std::endl;
   }
 }
 
 bool WitchBlastGame::loadGame()
 {
-  ifstream file(SAVE_FILE.c_str(), ios::in);
+  std::ifstream file(SAVE_FILE.c_str(), std::ios::in);
 
   if (file)
   {
@@ -2400,7 +2400,7 @@ WitchBlastGame::saveHeaderStruct WitchBlastGame::loadGameHeader()
   saveHeaderStruct saveHeader;
   saveHeader.ok = true;
 
-  ifstream file(SAVE_FILE.c_str(), ios::in);
+  std::ifstream file(SAVE_FILE.c_str(), std::ios::in);
 
   if (file)
   {

--- a/src/sfml_game/GameMap.cpp
+++ b/src/sfml_game/GameMap.cpp
@@ -112,7 +112,7 @@ void GameMap::randomize(int n)
 void GameMap::loadFromFile(const char* fileName)
 {
   hasChanged = true;
-  ifstream f(fileName);
+  std::ifstream f(fileName);
   if (!f.is_open()) return;
 
   int n;

--- a/src/sfml_game/GameMap.h
+++ b/src/sfml_game/GameMap.h
@@ -18,8 +18,6 @@
 
 #include <string>
 
-using namespace std ;
-
 class GameMap
 {
 public:


### PR DESCRIPTION
If you put 'using namespace std' into a header file, everything
that includes it will also be using namespace std implicitly, possibly
unintentionally.
