### PR TITLE
Add an opt-in CMake option to define ONLINE_MODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,13 @@ if(USING_GCC OR USING_CLANG)
   add_compile_options(-std=c++11 -pedantic -Wall)
 endif()
 
+# Compilation options
+option(ONLINE_MODE "Enable online mode, which requires src/OnlineScoring.h" OFF)
+
+if(ONLINE_MODE)
+  add_compile_options(-DONLINE_MODE)
+endif()
+
 include_directories(.)
 
 file(

--- a/src/WitchBlastGame.cpp
+++ b/src/WitchBlastGame.cpp
@@ -68,12 +68,11 @@
 
 #include <algorithm>
 
-//#define ONLINE_MODE
 #define LEVEL_TEST_MODE
 
 #ifdef ONLINE_MODE
 #include "OnlineScoring.h"
-#endif // ONLINE_SCORING
+#endif // ONLINE_MODE
 
 const float PORTRAIT_DIAPLAY_TIME = 5.0f;
 const unsigned int ACHIEV_LINES = 2;


### PR DESCRIPTION
Cleaner fix for #15

I rediffed my patch against the current branch. With this implementation is that you would have to run ```cmake -DONLINE_MODE=ON``` to initialise the project with online scores, but that's arguably better than having to manually edit src/WitchBlastGame.cpp :)