### PR TITLE
Only play fire animation if player is firing

### DIFF
--- a/src/PlayerEntity.cpp
+++ b/src/PlayerEntity.cpp
@@ -1677,7 +1677,7 @@ void PlayerEntity::rageFire(float damage, bool full, float velMult)
   SoundManager::getInstance().playSound(SOUND_BLAST_FIRE);
 }
 
-void PlayerEntity::resestFireDirection()
+void PlayerEntity::resetFireDirection()
 {
   firingDirection = 5;
 }
@@ -1889,6 +1889,10 @@ void PlayerEntity::fire(int direction)
     canFirePlayer = false;
     currentFireDelay = fireDelay;
     if (needInitShotType) initShotType();
+  }
+  else
+  {
+    resetFireDirection();
   }
 }
 

--- a/src/PlayerEntity.h
+++ b/src/PlayerEntity.h
@@ -118,7 +118,7 @@ class PlayerEntity : public BaseCreatureEntity
     /*!
      *  \brief reset the fire direction of the player
      */
-    void resestFireDirection();
+    void resetFireDirection();
 
     /*!
      *  \brief accessor on the fire direction of the player

--- a/src/WitchBlastGame.cpp
+++ b/src/WitchBlastGame.cpp
@@ -1411,7 +1411,7 @@ void WitchBlastGame::updateRunningGame()
       if (gameState == gameStatePlaying) player->castSpell();
     }
 
-    player->resestFireDirection();
+    player->resetFireDirection();
 
     if (isPressing(KeyFireLeft, false))
       player->fire(4);


### PR DESCRIPTION
Previously, the player will be in its firing animation
as long as the fire button is held down; this change
ensures the fire animation is only played after player shoots.