### PR TITLE
New items jump at start

### DIFF
--- a/src/ItemEntity.cpp
+++ b/src/ItemEntity.cpp
@@ -24,7 +24,7 @@ ItemEntity::ItemEntity(enumItemType itemType, float x, float y)
   setMap(game().getCurrentMap(), TILE_WIDTH, TILE_HEIGHT, 0, 0);
   isBeating = false;
   isFlying = false;
-  jumpTimer = 1.0f + 0.1f * (rand() % 40);
+  jumpTimer = 0;
   h = -1.0f;
 }
 


### PR DESCRIPTION
This makes new items like coins jump as they spawn, like out of chests.
I think it looks nicer than just sliding out; items in isaac and games like diablo also do this.

![jump](https://cloud.githubusercontent.com/assets/1083215/9834609/f02eaa2c-5a05-11e5-9ea4-5e86ceb9c55a.gif)
